### PR TITLE
Type consistency

### DIFF
--- a/Examples/test-suite/fortran/fortran_naming_runme.F90
+++ b/Examples/test-suite/fortran/fortran_naming_runme.F90
@@ -9,8 +9,11 @@ program fortran_naming_runme
   integer(C_INT) :: test_int
   type(Foo_) :: myfoo
   type(MyStruct) :: struct
-  type(SWIGTYPE_OpaqueStruct) :: opaque
-  type(SWIGTYPE_DeclaredStruct) :: declared
+  type(SWIGTYPE_p_OpaqueStruct) :: opaque
+  type(SWIGTYPE_p_p_OpaqueStruct) :: opaque_handle
+  type(SWIGTYPE_p_DeclaredStruct) :: declared
+  type(SWIGTYPE_p_IgnoredStruct) :: ignored
+  type(SWIGTYPE_p_TemplatedStructT_int_t) :: templated
 
   myfoo = Foo_()
   call myfoo%release()
@@ -27,8 +30,18 @@ program fortran_naming_runme
   ! The first enum _MYVAL should have priority over the later ones
   ASSERT(MYVAL_ == 1) 
 
-  opaque = make_opaque(123)
+  opaque = make_opaque_value(123)
   ASSERT(get_opaque_value(opaque) == 123)
+  opaque = get_opaque_ptr(opaque)
+  ASSERT(get_opaque_value(opaque) == 123)
+  opaque = get_opaque_ref(opaque)
+  ASSERT(get_opaque_value(opaque) == 123)
+  opaque = get_opaque_cptr(opaque)
+  ASSERT(get_opaque_value(opaque) == 123)
+  opaque = get_opaque_cref(opaque)
+  ASSERT(get_opaque_value(opaque) == 123)
+
+  opaque_handle = get_opaque_handle()
 
   ASSERT(f_123 == 123)
 
@@ -37,6 +50,12 @@ program fortran_naming_runme
 
   ! This will NOT work because of type safety for the unknown types
   ! ASSERT(get_opaque_value(declared) == 254)
+
+  ignored = make_ignored(979)
+  ASSERT(get_ignored_value(ignored) == 979)
+
+  templated = make_templated(409)
+  ASSERT(get_templated_value(templated) == 409)
 
   ! Check renamed long words
   ASSERT(sixty_four_characters_is_way_too_long_for_fortran_or_punc11LMB6 == 64)

--- a/Examples/test-suite/fortran/global_namespace_runme.F90
+++ b/Examples/test-suite/fortran/global_namespace_runme.F90
@@ -12,7 +12,8 @@ program global_namespace_runme
   type(Klass4) :: k4
   type(Klass5) :: k5
   type(Klass6) :: k6
-  type(Klass7) :: k7
+  type(Klass7) :: k7_wrapped
+  type(SWIGTYPE_p_p_Klass7) :: k7
   type(KlassMethods) :: km
   type(XYZ1) :: x1
   type(XYZ2) :: x2
@@ -20,7 +21,7 @@ program global_namespace_runme
   type(XYZ4) :: x4
   type(XYZ5) :: x5
   type(XYZ6) :: x6
-  type(XYZ7) :: x7
+  type(SWIGTYPE_p_p_Space__XYZ7) :: x7
   type(XYZMethods) :: xyzm
   type(TheEnumMethods) :: tem
 
@@ -30,7 +31,6 @@ program global_namespace_runme
   k4 = Klass4()
   k5 = Klass5()
   k6 = Klass6()
-  k7 = Klass7()
 
   call km%methodA(k1, k2, k3, k4, k5, k6, k7)
   call km%methodB(k1, k2, k3, k4, k5, k6, k7)
@@ -41,7 +41,6 @@ program global_namespace_runme
   call k4%release()
   call k5%release()
   call k6%release()
-  call k7%release()
 
   k1 = getKlass1A()
   k2 = getKlass2A()
@@ -49,10 +48,7 @@ program global_namespace_runme
   k4 = getKlass4A()
   k5 = getKlass5A()
   k6 = getKlass6A()
-  k7 = getKlass7A()
-
-  call km%methodA(k1, k2, k3, k4, k5, k6, k7)
-  call km%methodB(k1, k2, k3, k4, k5, k6, k7)
+  k7_wrapped = getKlass7A()
 
   call k1%release()
   call k2%release()
@@ -60,7 +56,6 @@ program global_namespace_runme
   call k4%release()
   call k5%release()
   call k6%release()
-  call k7%release()
 
   k1 = getKlass1B()
   k2 = getKlass2B()
@@ -68,7 +63,6 @@ program global_namespace_runme
   k4 = getKlass4B()
   k5 = getKlass5B()
   k6 = getKlass6B()
-  k7 = getKlass7B()
 
   call km%methodA(k1, k2, k3, k4, k5, k6, k7)
   call km%methodB(k1, k2, k3, k4, k5, k6, k7)
@@ -79,7 +73,6 @@ program global_namespace_runme
   call k4%release()
   call k5%release()
   call k6%release()
-  call k7%release()
 
   x1 = XYZ1()
   x2 = XYZ2()
@@ -87,7 +80,6 @@ program global_namespace_runme
   x4 = XYZ4()
   x5 = XYZ5()
   x6 = XYZ6()
-  x7 = XYZ7()
 
   call xyzm%methodA(x1, x2, x3, x4, x5, x6, x7)
   call xyzm%methodB(x1, x2, x3, x4, x5, x6, x7)
@@ -98,7 +90,6 @@ program global_namespace_runme
   call x4%release()
   call x5%release()
   call x6%release()
-  call x7%release()
 
   call tem%methodA(theenum1, theenum2, theenum3)
   call tem%methodA(theenum1, theenum2, theenum3)

--- a/Examples/test-suite/fortran_bindc.i
+++ b/Examples/test-suite/fortran_bindc.i
@@ -70,6 +70,8 @@ const SimpleStruct& get_cref() { return global_struct; }
 SimpleStruct * &get_ref_ptr() { return global_struct_ptr; }
 SimpleStruct const* & get_cref_ptr() { return global_struct_const_ptr; }
 
+void set_val_cpp(SimpleStruct s) { global_struct = s; }
+
 extern "C" {
 #endif
 

--- a/Examples/test-suite/fortran_naming.i
+++ b/Examples/test-suite/fortran_naming.i
@@ -138,13 +138,56 @@ enum Foo { GOOD, BAD };
 struct DeclaredStruct;
 enum Foo;
 
+%ignore IgnoredStruct;
+
 %inline %{
-  int get_opaque_value(const OpaqueStruct& o) { return o.i; }
-  OpaqueStruct make_opaque(int i) { OpaqueStruct os; os.i = i; return os; }
-  int get_declared_value(const DeclaredStruct& o) { return o.i; }
-  DeclaredStruct make_declared(int i) { DeclaredStruct o; o.i = i; return o; }
+struct IgnoredStruct { int i; };
+template<class T>
+struct TemplatedStruct { T i; };
+%}
+
+%template() TemplatedStruct<int>;
+
+%inline %{
+  OpaqueStruct make_opaque_value(int i) {
+    OpaqueStruct os;
+    os.i = i;
+    return os;
+  }
+  int get_opaque_value(OpaqueStruct o) { return o.i; }
+  OpaqueStruct *get_opaque_ptr(OpaqueStruct * o) { return o; }
+  const OpaqueStruct *get_opaque_cptr(const OpaqueStruct *o) { return o; }
+  OpaqueStruct &get_opaque_ref(OpaqueStruct & o) { return o; }
+  const OpaqueStruct &get_opaque_cref(const OpaqueStruct &o) { return o; }
+  OpaqueStruct const ** get_opaque_handle() {
+    static const OpaqueStruct* os = NULL;
+    return &os;
+  }
+
+  int get_declared_value(const DeclaredStruct &o) { return o.i; }
+  DeclaredStruct make_declared(int i) {
+    DeclaredStruct o;
+    o.i = i;
+    return o;
+  }
+  int get_ignored_value(const IgnoredStruct &o) { return o.i; }
+  IgnoredStruct make_ignored(int i) {
+    IgnoredStruct o;
+    o.i = i;
+    return o;
+  }
+  int get_templated_value(const TemplatedStruct<int> &o) { return o.i; }
+  TemplatedStruct<int> make_templated(int i) {
+    TemplatedStruct<int> o;
+    o.i = i;
+    return o;
+  }
   int get_value(Foo f) { return static_cast<int>(f); }
-  DelayedStruct make_delayed(int i) { DelayedStruct o; o.i = i; return o; }
+  DelayedStruct make_delayed(int i) {
+    DelayedStruct o;
+    o.i = i;
+    return o;
+  }
 %}
 
 struct DelayedStruct { int i; };

--- a/Lib/fortran/classes.swg
+++ b/Lib/fortran/classes.swg
@@ -288,11 +288,11 @@ SWIGINTERN void SWIG_assign(SwigClassWrapper* self, SwigClassWrapper other) {
 %typemap(imtype, fragment="SwigClassWrapper_f")
     SWIGTYPE
   "type(SwigClassWrapper)"
-%typemap(ftype, in="type($fclassname), intent(in)", nofortransubroutine=1) SWIGTYPE
-  "type($fclassname)"
+%typemap(ftype, in="type($&fclassname), intent(in)", nofortransubroutine=1) SWIGTYPE
+  "type($&fclassname)"
 
 %typemap(in, noblock=1, fragment="SWIG_check_nonnull") SWIGTYPE {
-  SWIG_check_nonnull(*$input, "$1_ltype", "$fclassname", "$decl", return $null);
+  SWIG_check_nonnull(*$input, "$1_ltype", "$&fclassname", "$decl", return $null);
   $1 = *%static_cast($input->cptr, $&1_ltype);
 }
 %typemap(out, noblock=1) SWIGTYPE {
@@ -321,7 +321,7 @@ SWIGINTERN void SWIG_assign(SwigClassWrapper* self, SwigClassWrapper other) {
   $result.cptr = $1;
   $result.cmemflags = SWIG_MEM_RVALUE | ($owner ? SWIG_MEM_OWN : 0);
 }
-%typemap(bindc) SWIGTYPE* "void*";
+%typemap(bindc) SWIGTYPE* "type(C_PTR)";
 
 // >>> CONST POINTER
 
@@ -358,18 +358,17 @@ SWIGINTERN void SWIG_assign(SwigClassWrapper* self, SwigClassWrapper other) {
 // >>> OTHERS
 
 // Treat arrays of classes as opaque pointers
-%apply void * { SWIGTYPE [], SWIGTYPE [ANY] };
-%apply const void * { const SWIGTYPE [], const SWIGTYPE [ANY] };
+%apply SWIGTYPE* { SWIGTYPE [], SWIGTYPE [ANY] };
+%apply SWIGTYPE* { const SWIGTYPE [], const SWIGTYPE [ANY] };
 
 // Treat const-references-to-pointers as pointers
+%typemap(ftype, in="class($*fclassname), intent(inout)", nofortransubroutine=1) SWIGTYPE *MUTABLE_SELF
+  "type($*fclassname)"
 %apply SWIGTYPE * { const SWIGTYPE *const& };
 %typemap(in, noblock=1) SWIGTYPE *const & ($*1_ltype temp)
   {temp = %static_cast($input->cptr, $*1_ltype);
    $1 = &temp;}
 
-// Treat const references to const pointers the same way
-%apply SWIGTYPE *const& { const SWIGTYPE *const& };
-   
 // C binding for opaque classes for advanced users
 %typemap(bindc, in="type(SwigClassWrapper), value", fragment="SwigClassWrapper_f") SwigClassWrapper
   "type(SwigClassWrapper)"
@@ -382,12 +381,12 @@ SWIGINTERN void SWIG_assign(SwigClassWrapper* self, SwigClassWrapper other) {
 
 // Check for non-null, mutable class input "self"
 %typemap(in, noblock=1, fragment="SWIG_check_mutable_nonnull") SWIGTYPE *self {
-  SWIG_check_mutable_nonnull(*$input, "$1_type", "$fclassname", "$decl", return $null);
+  SWIG_check_mutable_nonnull(*$input, "$1_type", "$*fclassname", "$decl", return $null);
   $1 = %static_cast($input->cptr, $1_ltype);
 }
 // Check for non-null class input "self"
 %typemap(in, noblock=1, fragment="SWIG_check_nonnull") const SWIGTYPE *self {
-  SWIG_check_nonnull(*$input, "$1_type", "$fclassname", "$decl", return $null);
+  SWIG_check_nonnull(*$input, "$1_type", "$*fclassname", "$decl", return $null);
   $1 = %static_cast($input->cptr, $1_ltype);
 }
 

--- a/Lib/fortran/fundamental.swg
+++ b/Lib/fortran/fundamental.swg
@@ -336,20 +336,20 @@ end function
  * A 'void**' looks like a FORTRAN_INTRINSIC_TYPE* where FORTRAN_INTRINSIC_TYPE is 'void*' (aka C_PTR)
  * ------------------------------------------------------------------------- */
 
-%apply void* { SWIGTYPE** };
-%typemap(ftype, in="type(C_PTR), target, intent(inout)") SWIGTYPE**
+%apply void* { void** };
+%typemap(ftype, in="type(C_PTR), target, intent(inout)") void**
   "type(C_PTR), pointer"
-%typemap(fin) SWIGTYPE** = FORTRAN_INTRINSIC_TYPE*;
-%typemap(fout) SWIGTYPE** = FORTRAN_INTRINSIC_TYPE*;
-%apply SWIGTYPE** { SWIGTYPE*&, SWIGTYPE *const* };
+%typemap(fin) void** = FORTRAN_INTRINSIC_TYPE*;
+%typemap(fout) void** = FORTRAN_INTRINSIC_TYPE*;
+%apply void** { void*&, void *const* };
 
-%apply const void* { const SWIGTYPE** };
-%typemap(ftype, in="type(C_PTR), target, intent(in)") const SWIGTYPE**
+%apply const void* { const void** };
+%typemap(ftype, in="type(C_PTR), target, intent(in)") const void**
   "type(C_PTR), pointer"
-%typemap(fin) const SWIGTYPE** = const FORTRAN_INTRINSIC_TYPE*;
-%typemap(fout) const SWIGTYPE** = const FORTRAN_INTRINSIC_TYPE*;
-%apply const SWIGTYPE** { const SWIGTYPE*&, const SWIGTYPE *const*,
-SWIGTYPE ** const, SWIGTYPE **const &};
+%typemap(fin) const void** = const FORTRAN_INTRINSIC_TYPE*;
+%typemap(fout) const void** = const FORTRAN_INTRINSIC_TYPE*;
+%apply const void** { const void*&, const void *const*,
+void ** const, void **const &};
 
 /* -------------------------------------------------------------------------
  * FUNDAMENTAL TYPES

--- a/Lib/fortran/fundamental.swg
+++ b/Lib/fortran/fundamental.swg
@@ -97,7 +97,7 @@ end function
   %typemap(fin) CTYPE = FORTRAN_INTRINSIC_TYPE;
   %typemap(fout) CTYPE = FORTRAN_INTRINSIC_TYPE;
 
-  // XXX I'd like to do this as FORTRAN_INTRINSIC_TYPE, but because $1_basetype doesn't work properly, and there's no way to do `$**1_ltype`, we have to explicitly add
+  // XXX I'd like to do this as FORTRAN_INTRINSIC_TYPE, but because $1_basetype doesn't work as expected, and there's no way to do `$**1_ltype`, we have to explicitly add
   // these here.
   %typemap(ftype, in={FTYPE, target, intent(inout)}, noblock=1) CTYPE *const & {
     FTYPE, pointer

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -2406,7 +2406,7 @@ int FORTRAN::memberfunctionHandler(Node *n) {
   }
 
   // Create a private procedure name that gets bound to the Fortan TYPE
-  String *fwrapname = proxy_name_construct(this->getNSpace(), class_symname,Getattr(n, "sym:name"));
+  String *fwrapname = proxy_name_construct(this->getNSpace(), class_symname, Getattr(n, "sym:name"));
   Setattr(n, "fortran:fname", fwrapname);
   Delete(fwrapname);
 
@@ -2972,7 +2972,7 @@ String *FORTRAN::get_fclassname(SwigType *classnametype) {
       }
     }
   }
-
+    
   return replacementname;
 }
 


### PR DESCRIPTION
Make opaque or unusual objects typesafe, again trending toward the behavior of Java and other SWIG target languages.