### PR TITLE
minor tweak to make docstrings get picked up by doxygen

### DIFF
--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -2092,7 +2092,7 @@ void FORTRAN::write_docstring(Node *n, String *dest) {
 
   for (; it.item; it = Next(it)) {
     // Chop(it.item);
-    Printv(dest, "! ", it.item, "\n", NULL);
+    Printv(dest, "!> ", it.item, "\n", NULL);
   }
 
   Delete(lines);


### PR DESCRIPTION
Though only a single character was added (">"), this is technically twice a big as the smallest possible commit, since two keystrokes were involved.