### PR TITLE
SWIG-like pointers

### DIFF
--- a/Doc/Manual/src/Fortran.md
+++ b/Doc/Manual/src/Fortran.md
@@ -1215,8 +1215,8 @@ Fortran arrays to interact natively with fixed-size C arrays:
 
 ```swig
 %include <typemaps.i>
-%apply ARRAY[ANY] { int global[4] };
-%apply ARRAY[ANY][ANY] { double[ANY][ANY] };
+%apply SWIGTYPE ARRAY[ANY] { int global[4] };
+%apply SWIGTYPE ARRAY[ANY][ANY] { double[ANY][ANY] };
 
 double cpp_sum(const double inp[3][2]);
 

--- a/Doc/Manual/src/Fortran.md
+++ b/Doc/Manual/src/Fortran.md
@@ -287,7 +287,7 @@ extend the
 Fortran/C++ mapping as much as possible, keeping in mind that Fortran and C are
 inherently different languages.
 
-## Arithmetic types
+## Fundamental types
 
 SWIG maps ISO C types to Fortran types using the `ISO_C_BINDING` intrinsic
 module. The data types fully supported by C, Fortran, and SWIG are:
@@ -304,8 +304,7 @@ module. The data types fully supported by C, Fortran, and SWIG are:
 | `double`        | `real(C_DOUBLE)`        |
 | `char`          | `character(C_CHAR)`     |
 
-Pointers and references to these basic types are returned as scalar Fortran
-pointers.
+References to these basic types are returned as scalar Fortran pointers.
 
 Note that because the C return value does not contain any information about the
 shape of the data being pointed to, it is not possible to directly construct an
@@ -357,12 +356,12 @@ typedef char NativeChar;
 char *get_my_char_ptr();
 ```
 
-## Pointers and references
+### References
 
-C pointers and mutable references are treated as Fortran pointers. Suppose a C
-function that returns a pointer to an array element at a given index:
+C mutable references are treated as Fortran pointers. Suppose a C
+function that returns a reference to an array element at a given index:
 ```c
-double *get_array_element(int x);
+double &get_array_element(int x);
 ```
 
 This generates the following Fortran interface:
@@ -390,7 +389,7 @@ rptr = 512.0d0
 Note, and this is **very important**, that a function returning a pointer must
 not be *assigned*; the *pointer assignment* operator `=>` must be used.
 
-Mutable references are treated identically. However, *const* references to
+Unlike mutable references, *const* references to
 primitive arithmetic types are treated as values:
 ```c++
 const double &get_const_array_element(int x);

--- a/Examples/fortran/bare/example.cxx
+++ b/Examples/fortran/bare/example.cxx
@@ -36,24 +36,12 @@ const double &get_something_rcref(int x) {
   return data[x];
 }
 
-double *get_something_rptr(int x) {
-  return data + x;
-}
-
-const double *get_something_rcptr(int x) {
-  return data + x;
-}
-
 double &get_something_rref(int x) {
   return data[x];
 }
 
 void get_something_ref(int x, double &y) {
   y = get_something(x);
-}
-
-void get_something_ptr(int x, double *y) {
-  *y = get_something(x);
 }
 
 /* ------------------------------------------------------------------------- */

--- a/Examples/fortran/bare/example.h
+++ b/Examples/fortran/bare/example.h
@@ -10,10 +10,7 @@
 void set_something(int x, double y);
 double get_something(int x);
 void get_something_ref(int x, double &y);
-void get_something_ptr(int x, double *y);
 
-double *get_something_rptr(int x);
-const double *get_something_rcptr(int x);
 double &get_something_rref(int x);
 const double &get_something_rcref(int x);
 

--- a/Examples/fortran/bare/runme.f90
+++ b/Examples/fortran/bare/runme.f90
@@ -22,8 +22,6 @@ subroutine test_funcs()
   rptr => get_something_rref(2)
   rptr = 512.0d0
 
-  call get_something_ptr(2, temp)
-  write(0, *) "Got ", temp
   call get_something_ref(1, temp)
   write(0, *) "Got ", temp
 

--- a/Examples/fortran/bindc/example.cxx
+++ b/Examples/fortran/bindc/example.cxx
@@ -54,8 +54,8 @@ void make_point(Point *pt, const double xyz[3]) {
   pt->z = xyz[2];
 }
 
-void print_sphere(const Point *origin, const double *radius) {
-  cout << "Sphere: r=" << *radius
+void print_sphere(const Point *origin, const double radius) {
+  cout << "Sphere: r=" << radius
        << ", "
           "origin={"
        << origin->x << ',' << origin->y << ',' << origin->z << "}" << endl;

--- a/Examples/fortran/bindc/example.h
+++ b/Examples/fortran/bindc/example.h
@@ -20,7 +20,7 @@ extern "C" {
 
 // These functions are simply bound, not wrapped.
 void make_point(Point *pt, const double xyz[3]);
-void print_sphere(const Point *origin, const double *radius);
+void print_sphere(const Point *origin, const double radius);
 bool bound_negation(bool v);
 
 /* ------------------------------------------------------------------------- */

--- a/Examples/test-suite/arrays.i
+++ b/Examples/test-suite/arrays.i
@@ -12,6 +12,7 @@ This test case tests that various types of arrays are working.
 %rename(ArrSt) ArrayStruct;
 #endif
 
+
 %inline %{
 #define ARRAY_LEN 2
 
@@ -56,6 +57,16 @@ int getintfrompointer(int* intptr) {
 }
 
 %}
+
+#if defined(SWIGFORTRAN)
+/* Pointer helper functions for Fortan run test */
+%include "typemaps.i"
+%apply SWIGTYPE ARRAY[ANY] { int inp[ANY]  };
+%inline %{
+int *array_to_ptr(int inp[ARRAY_LEN]) { return inp; }
+int get_value(int *inp, int idx) { return inp[idx - 1]; }
+%}
+#endif
 
 // This tests wrapping of function that involves pointer to array
 

--- a/Examples/test-suite/fortran/array_member_runme.F90
+++ b/Examples/test-suite/fortran/array_member_runme.F90
@@ -7,31 +7,28 @@ program array_member_runme
   use ISO_C_BINDING
   implicit none
   type(Foo) :: f
-  integer(C_INT), dimension(:), pointer :: global_data, local_data
   integer :: i
 
   f = Foo()
-  global_data => get_global_data()
-  call f%set_data(global_data)
+  call f%set_data(get_global_data())
 
   ! Note that because the C++ declaration is int*, it requires a scalar data pointer, so we pass the first element of the
   ! pointer array (which is 1 in fortran indexing).
-  local_data => f%get_data()
   ! In Fortran, loops are inclusive of the range.
   do i = 0, 7
-    ASSERT(get_value(local_data(1), i) == get_value(global_data(1), i))
+    ASSERT(get_value(f%get_data(), i) == get_value(get_global_data(), i))
   end do
 
   do i = 0, 7
-    call set_value(local_data(1), i, -i)
+    call set_value(f%get_data(), i, -i)
   end do
 
   ! *assign* the data
-  global_data = f%get_data()
+  call set_global_data(f%get_data())
 
   ! Now check it
   do i = 0, 7
-    ASSERT(get_value(local_data(1), i) == get_value(global_data(1), i))
+    ASSERT(get_value(f%get_data(), i) == get_value(get_global_data(), i))
   end do
 end program
 

--- a/Examples/test-suite/fortran/arrays_global_twodim_runme.F90
+++ b/Examples/test-suite/fortran/arrays_global_twodim_runme.F90
@@ -1,0 +1,45 @@
+! File : arrays_global_twodim.F90
+
+#include "fassert.h"
+
+program arrays_global_twodim
+  use ISO_C_BINDING
+  implicit none
+
+  call test_int_array
+contains
+
+subroutine test_int_array  
+  use arrays_global_twodim
+  use ISO_C_BINDING
+  implicit none
+  ! The following will fail to build if they're not defined as PARAMETERS in the module file
+  type(SWIGTYPE_p_a_4__int) :: constintarray2d
+  type(SWIGTYPE_p_a_4__int) :: intarray2d
+  integer(C_INT) :: cnt = 10
+  integer(C_INT) :: x, y
+  integer(C_INT), dimension(:,:), allocatable :: expected, actual
+
+  constintarray2d = get_array_const_i()
+  intarray2d = get_array_i()
+
+  call set_array_i(constintarray2d)
+
+  allocate(expected(ARRAY_LEN_Y, ARRAY_LEN_X))
+  allocate(actual(ARRAY_LEN_Y, ARRAY_LEN_X))
+
+  do x = 1, ARRAY_LEN_X
+    do y = 1, ARRAY_LEN_Y
+      expected(y, x) = cnt
+      cnt = cnt + 1
+      actual(y, x) = get_2d_array(intarray2d, x - 1, y - 1)
+    end do
+  end do
+
+  write(*,*) "Expected:", expected
+  write(*,*) "Actual:", actual
+  ASSERT(all(expected == actual))
+end subroutine
+end program
+
+

--- a/Examples/test-suite/fortran/arrays_runme.F90
+++ b/Examples/test-suite/fortran/arrays_runme.F90
@@ -14,14 +14,13 @@ subroutine test_arrays
   implicit none
   type(ArrayStruct) :: arr
   integer(C_INT), dimension(2) :: actual = [ 91, 420 ]
-  integer(C_INT), dimension(:), pointer :: got_arr
+  type(SWIGTYPE_p_int) :: got_arr
   arr = ArrayStruct()
-  call arr%set_array_i(actual)
+  call arr%set_array_i(array_to_ptr(actual))
 
-  got_arr => arr%get_array_i()
-  write(0,*) got_arr
-
-  ASSERT(all(got_arr == actual))
+  got_arr = arr%get_array_i()
+  ASSERT(get_value(got_arr, 1) == actual(1))
+  ASSERT(get_value(got_arr, 2) == actual(2))
 
 end subroutine
 end program

--- a/Examples/test-suite/fortran/fortran_array_typemap_runme.F90
+++ b/Examples/test-suite/fortran/fortran_array_typemap_runme.F90
@@ -3,6 +3,16 @@
 #include "fassert.h"
 
 program fortran_array_typemap_runme
+  use ISO_C_BINDING
+  implicit none
+
+  call test_ptr_size
+  call test_fixed
+
+contains
+
+! Test two-argument (pointer + size) -> dynamic
+subroutine test_ptr_size
   use fortran_array_typemap
   use ISO_C_BINDING
   implicit none
@@ -15,6 +25,36 @@ program fortran_array_typemap_runme
   ASSERT(all(int_values == 2))
   ASSERT(all(dbl_values == 4.25d0))
   ASSERT(accum(int_values) == 2 * 4)
+end subroutine
+
+! Test two-argument (pointer + size) -> dynamic
+subroutine test_fixed
+  use fortran_array_typemap
+  use ISO_C_BINDING
+  implicit none
+  real(C_DOUBLE), dimension(2,3) :: dbl_values
+  integer(C_INT), dimension(4)  :: int_values = [1,2,3,4]
+  integer :: i, j
+
+  call set_global(int_values)
+  int_values(:) = 0
+  int_values = get_global()
+
+  do i = 1, 4
+    ASSERT(int_values(i) == i)
+  end do
+
+  do j = 1,2
+    do i = 1,3
+      dbl_values(j,i) = real(i + 10 * j, C_DOUBLE)
+    end do
+  end do
+
+  write(0,*) "dbl_values:", dbl_values
+  write(0,*) "cpp_sum(dbl_values):", cpp_sum(dbl_values)
+  ASSERT(cpp_sum(dbl_values) == sum(dbl_values))
+end subroutine
+
 end program
 
 

--- a/Examples/test-suite/fortran/fortran_bindc_runme.F90
+++ b/Examples/test-suite/fortran/fortran_bindc_runme.F90
@@ -28,30 +28,11 @@ subroutine test_arrays
   use fortran_bindc
   use ISO_C_BINDING
   implicit none
-  type(XY), allocatable :: globalxyarr(:)
   type(XYArray) :: xyarr
-  type(XYArray) :: xyarr_ptr
   type(XY) :: tempxy
   integer :: i
   integer(c_short) :: short_array(5) = [ 5_c_short, 40_c_short, 300_c_short, 2000_c_short, 10000_c_short ]
   integer(c_short) :: summed
-
-  ! Get a copy of the global xy array
-  globalxyarr = get_globalXYArray()
-  ASSERT(size(globalxyarr) == 3)
-  do i = 1,3
-    globalxyarr(i)%x = i * 2
-    globalxyarr(i)%y = i * 2 + 1
-  end do
-  write(0,*) "Global values:", globalxyarr
-
-  ! Get a C pointer to the global xy array using a static method
-  xyarr_ptr = xyarr_ptr%frompointer(globalxyarr(1))
-
-  ! Check the values: 0 C indexing => 1 Fortran indexing
-  tempxy = xyarr_ptr%getitem(0)
-  ASSERT(tempxy%x == 2)
-  ASSERT(tempxy%y == 3)
 
   ! Allocate a new C array
   xyarr = XYArray(3);
@@ -60,15 +41,6 @@ subroutine test_arrays
     tempxy%y = 10 * i + 1
     call xyarr%setitem(i - 1, tempxy)
   end do
-
-  if (is_cplusplus == 0) then
-    ! C assignment: copy xyarr to the object pointed to by xyarr_ptr (i.e. the global array) . This works because the default assingnment traits do a memcpy,
-    ! but the C++ class lacks a copy assignment operator.
-    xyarr_ptr = xyarr
-    
-    ASSERT(globalxyarr(1)%x == 10)
-    ASSERT(globalxyarr(1)%y == 11)
-  end if
 
   ! Sum a fortran array using a bound(C) function
   summed = sum_array(short_array)

--- a/Examples/test-suite/fortran/fortran_bindc_runme.F90
+++ b/Examples/test-suite/fortran/fortran_bindc_runme.F90
@@ -28,7 +28,7 @@ subroutine test_arrays
   use fortran_bindc
   use ISO_C_BINDING
   implicit none
-  type(XY), pointer :: globalxyarr(:)
+  type(XY), allocatable :: globalxyarr(:)
   type(XYArray) :: xyarr
   type(XYArray) :: xyarr_ptr
   type(XY) :: tempxy
@@ -36,16 +36,14 @@ subroutine test_arrays
   integer(c_short) :: short_array(5) = [ 5_c_short, 40_c_short, 300_c_short, 2000_c_short, 10000_c_short ]
   integer(c_short) :: summed
 
-  ! Get a fortran pointer to the global xy array
-  globalxyarr => get_globalXYArray()
+  ! Get a copy of the global xy array
+  globalxyarr = get_globalXYArray()
   ASSERT(size(globalxyarr) == 3)
   do i = 1,3
     globalxyarr(i)%x = i * 2
     globalxyarr(i)%y = i * 2 + 1
   end do
-
-  ! Global array should have the same values
-  write(0,*) "Global values:", get_globalXYArray()
+  write(0,*) "Global values:", globalxyarr
 
   ! Get a C pointer to the global xy array using a static method
   xyarr_ptr = xyarr_ptr%frompointer(globalxyarr(1))

--- a/Examples/test-suite/fortran_array_typemap.i
+++ b/Examples/test-suite/fortran_array_typemap.i
@@ -3,6 +3,8 @@
 
 %include <typemaps.i>
 
+/* Test combination pointer/size arguments */
+
 %apply (SWIGTYPE *DATA, size_t SIZE)       { (int *DATA, size_t SIZE) };
 %apply (const SWIGTYPE *DATA, size_t SIZE) { (const int *DATA, size_t SIZE) };
 %apply (const SWIGTYPE *DATA, size_t SIZE) { (double *DATA, int SIZE) };
@@ -36,4 +38,22 @@ int accum(const int *DATA, size_t SIZE) {
 
 %}
 
+/* Test fixed-size arguments */
+
+%apply ARRAY[ANY] { int global[4] };
+%apply ARRAY[ANY][ANY] { double[ANY][ANY] };
+
+%inline %{
+int global[4] = {0,0,0,0};
+
+double cpp_sum(const double inp[3][2]) {
+  double result = 0;
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 2; ++j) {
+      result += inp[i][j];
+    }
+  }
+  return result;
+}
+%}
 

--- a/Examples/test-suite/fortran_array_typemap.i
+++ b/Examples/test-suite/fortran_array_typemap.i
@@ -40,8 +40,8 @@ int accum(const int *DATA, size_t SIZE) {
 
 /* Test fixed-size arguments */
 
-%apply ARRAY[ANY] { int global[4] };
-%apply ARRAY[ANY][ANY] { double[ANY][ANY] };
+%apply SWIGTYPE ARRAY[ANY] { int global[4] };
+%apply SWIGTYPE ARRAY[ANY][ANY] { double[ANY][ANY] };
 
 %inline %{
 int global[4] = {0,0,0,0};

--- a/Examples/test-suite/fortran_array_typemap.i
+++ b/Examples/test-suite/fortran_array_typemap.i
@@ -48,8 +48,9 @@ int global[4] = {0,0,0,0};
 
 double cpp_sum(const double inp[3][2]) {
   double result = 0;
-  for (int i = 0; i < 3; ++i) {
-    for (int j = 0; j < 2; ++j) {
+  int i, j;
+  for (i = 0; i < 3; ++i) {
+    for (j = 0; j < 2; ++j) {
       result += inp[i][j];
     }
   }

--- a/Examples/test-suite/fortran_bindc.i
+++ b/Examples/test-suite/fortran_bindc.i
@@ -15,6 +15,8 @@
 %fortranbindc get_cptr;
 %fortranbindc get_handle;
 
+%fortranbindc sum_array;
+
 // Bind some global variables
 %fortranbindc my_global_int;
 %fortranbindc my_const_global_int;
@@ -133,6 +135,9 @@ AB globalABArray[3];
 %array_functions(AB, ABArray)
 
 %inline %{
+#ifdef __cplusplus
+extern "C" {
+#endif
 short sum_array(short x[5]) {
   short sum = 0;
   int i;
@@ -141,6 +146,9 @@ short sum_array(short x[5]) {
   }
   return sum;
 }
+#ifdef __cplusplus
+}
+#endif
 %}
 
 %fortranbindc oned_unknown;

--- a/Examples/test-suite/fortran_naming.i
+++ b/Examples/test-suite/fortran_naming.i
@@ -104,7 +104,7 @@ enum AlsoOmitted {
 
 // Even though the Fortran identifier must be renamed, the function it's
 // bound to cannot.
-extern "C" int _0cboundfunc(const int* _x) { return *_x + 1; }
+extern "C" int _0cboundfunc(const int _x) { return _x + 1; }
 
 %}
 

--- a/Examples/test-suite/fortran_overloads.i
+++ b/Examples/test-suite/fortran_overloads.i
@@ -19,14 +19,14 @@ public:
  int func(int a) { return a; }
  virtual int func(int a, int b) { return a + b; }
  void func(int, int, int) {} // !! Can't overload subroutine with functions
- void sub(int *x) { *x = 123; }
+ void sub(int &x) { x = 123; }
 };
 
 class DerivedOverloads : public Base {
  public:
   double func(double, double) {return 1.0;}
   virtual int func(int x, int y) { return x - y; } // !! different parameter names
-  void sub(int *x) { *x = 456; } // overrides, won't apply if called as base class
+  void sub(int &x) { x = 456; } // overrides, won't apply if called as base class
 };
 
 class DerivedDerived : public DerivedOverloads {

--- a/Examples/test-suite/fortran_subroutine.i
+++ b/Examples/test-suite/fortran_subroutine.i
@@ -42,8 +42,8 @@ int multiply(int a, int b) {
   return a * b;
 }
 
-void already_a_subroutine(int a, int *b) {
-  *b = a;
+void already_a_subroutine(int a, int &b) {
+  b = a;
 }
 
 bool still_a_function() { return true; }

--- a/Examples/test-suite/funcptr.i
+++ b/Examples/test-suite/funcptr.i
@@ -3,7 +3,7 @@
 /*
  Complicated one that should defeat just reading , to find
  the number of arguments expected in the function pointer.
-extern void do(int (*op)(int (*i)(double, double), int j)); 
+extern void do(int (*op)(int (*i)(double, double), int j));
 */
 %{
 #include <stdlib.h>
@@ -40,18 +40,18 @@ int multiply(int a, int b) {
   return a*b;
 }
 
-int *nowt() { 
+int *nowt() {
   return 0;
 }
 
-int *nowt2(void) { 
+int *nowt2(void) {
   return 0;
 }
 
 struct MyStruct { int i; };
 typedef struct MyStruct * MyStructPtr;
 
-MyStructPtr mystructptr() { 
+MyStructPtr mystructptr() {
   return 0;
 }
 
@@ -67,6 +67,15 @@ void (*pfunc0)();
 int (*pfuncA)();
 void (*pfunc1)(int);
 void (*pfunc2)(int, double);
+
+#ifdef SWIGFORTRAN
+// Temporary example of setting function handles. This will be improved.
+%apply void* { SWIGTYPE (**)(ANY) } ;
+
+%typemap(fin) SWIGTYPE (**)(ANY) = FORTRAN_INTRINSIC_TYPE&;
+%typemap(ftype, in="type(C_FUNPTR), target, intent(inout)") SWIGTYPE (**)(ANY)
+  "type(C_FUNPTR), pointer"
+#endif
 
 void set_handle(int choice, Operator* op) {
   switch (choice) {

--- a/Examples/test-suite/template_array_numeric.i
+++ b/Examples/test-suite/template_array_numeric.i
@@ -1,5 +1,11 @@
 %module template_array_numeric
 
+#ifdef SWIGFORTRAN
+/* Make unit testing easier for Fortran */
+%include <typemaps.i>
+%apply SWIGTYPE ARRAY[ANY] {const float [ANY] };
+#endif
+
 %inline %{
 
 template <int Len>

--- a/Lib/fortran/bindc.swg
+++ b/Lib/fortran/bindc.swg
@@ -38,6 +38,10 @@
   %apply FORTRAN_STRUCT_TYPE { CLS };
   %fortran_apply_typemaps(FORTRAN_STRUCT_TYPE, CLS)
 
+  // Override 'SWIGTYPE' behavior for pointers to make it behave like references. Otherwise it behaves like SWIGTYPE*, which is wrapped as a class; as
+  // opposed to int*, which is wrapped as an opaque type.
+  %apply FORTRAN_INTRINSIC_TYPE& { CLS*, CLS[], CLS[ANY] };
+
   // Set up C type
   %typemap(ctype, in={const CLS*}, null={SWIG_null_struct_ ## CLS()}, fragment="SWIG_null_struct"{CLS}, noblock=1) CLS {
     CLS

--- a/Lib/fortran/classes.swg
+++ b/Lib/fortran/classes.swg
@@ -355,10 +355,6 @@ SWIGINTERN void SWIG_assign(SwigClassWrapper* self, SwigClassWrapper other) {
 
 // >>> OTHERS
 
-// Treat arrays of classes as opaque pointers
-%apply SWIGTYPE* { SWIGTYPE [], SWIGTYPE [ANY] };
-%apply SWIGTYPE* { const SWIGTYPE [], const SWIGTYPE [ANY] };
-
 // Treat const-references-to-pointers as pointers
 %typemap(ftype, in="class($*fclassname), intent(inout)", nofortransubroutine=1) SWIGTYPE *MUTABLE_SELF
   "type($*fclassname)"

--- a/Lib/fortran/classes.swg
+++ b/Lib/fortran/classes.swg
@@ -321,6 +321,10 @@ SWIGINTERN void SWIG_assign(SwigClassWrapper* self, SwigClassWrapper other) {
 }
 %typemap(bindc) SWIGTYPE* "type(C_PTR)";
 
+// >>> ARRAY
+
+%apply SWIGTYPE* { SWIGTYPE[] };
+
 // >>> CONST POINTER
 
 // Immutable pointers to mutable classes

--- a/Lib/fortran/enums.swg
+++ b/Lib/fortran/enums.swg
@@ -17,7 +17,8 @@
   $result = %static_cast($1, int);
 }
 
+%typemap(ftype, in="integer($*fenumname), intent(in)") const enum SWIGTYPE&
+  "integer($*fenumname)"
 %typemap(imtype) const enum SWIGTYPE& = enum SWIGTYPE;
-%typemap(ftype)  const enum SWIGTYPE& = enum SWIGTYPE;
 %typemap(fin)    const enum SWIGTYPE& = enum SWIGTYPE;
 %typemap(fout)   const enum SWIGTYPE& = enum SWIGTYPE;

--- a/Lib/fortran/enums.swg
+++ b/Lib/fortran/enums.swg
@@ -14,7 +14,10 @@
 %typemap(ftype, in="integer($fenumname), intent(in)") enum SWIGTYPE
   "integer($fenumname)"
 %typemap(out, noblock=1) enum SWIGTYPE {
-  $result = %static_cast($1, int);
+  $result = (int)($1);
+}
+%typemap(out, noblock=1) const enum SWIGTYPE& {
+  $result = (int)(*$1);
 }
 
 %typemap(ftype, in="integer($*fenumname), intent(in)") const enum SWIGTYPE&

--- a/Lib/fortran/enums.swg
+++ b/Lib/fortran/enums.swg
@@ -9,7 +9,7 @@
 // Most of the opertions are like integers, but replace the fortran wrapper
 // with the kind of enum. Don't worry about pointer types (leave those as
 // integer pointers)
-%fortran_apply_unsigned(int, enum SWIGTYPE)
+%fortran_unsigned(int, enum SWIGTYPE)
 
 %typemap(ftype, in="integer($fenumname), intent(in)") enum SWIGTYPE
   "integer($fenumname)"

--- a/Lib/fortran/fortran.swg
+++ b/Lib/fortran/fortran.swg
@@ -86,8 +86,8 @@
 %include "fortrankw.swg"
 
 /* TYPEMAPS */
-%include "fundamental.swg"
 %include "classes.swg"
+%include "fundamental.swg"
 %include "enums.swg"
 %include "fortranstrings.swg"
 %include "bindc.swg"

--- a/Lib/fortran/fundamental.swg
+++ b/Lib/fortran/fundamental.swg
@@ -77,14 +77,9 @@ end subroutine
  */
 %define %fortran_apply_typemaps(SRCTYPE, DSTTYPE)
   // Copy all relevant typemaps
-  %apply SRCTYPE*               { DSTTYPE* };
-  %apply SRCTYPE&               { DSTTYPE& };
-  %apply SRCTYPE* const&        { DSTTYPE* const& };
-  %apply SRCTYPE&&              { DSTTYPE&& };
-
-  %apply const SRCTYPE*        { const DSTTYPE* };
-  %apply const SRCTYPE&        { const DSTTYPE& };
-  %apply const SRCTYPE* const& { const DSTTYPE* const& };
+  %apply SRCTYPE&       { DSTTYPE& };
+  %apply SRCTYPE&&      { DSTTYPE&& };
+  %apply const SRCTYPE& { const DSTTYPE& };
 %enddef
 
 /*!
@@ -110,14 +105,6 @@ end subroutine
 
   %typemap(fin) CTYPE = FORTRAN_INTRINSIC_TYPE;
   %typemap(fout) CTYPE = FORTRAN_INTRINSIC_TYPE;
-
-  %typemap(ftype, in={FTYPE, target, intent(inout)}, noblock=1) CTYPE *const & {
-    FTYPE, pointer
-  }
-  %typemap(ctype, noblock=1) CTYPE *const & {
-    const CTYPE*
-  }
-
 %enddef
 
 /*!
@@ -131,7 +118,7 @@ end subroutine
   %typemap(out, noblock=1)
     DSTTYPE*, DSTTYPE&,
     const DSTTYPE*, const DSTTYPE& {
-     $result = %reinterpret_cast($1, SRCTYPE*);
+     $result = (SRCTYPE*)($1);
   }
 %enddef
 
@@ -164,10 +151,10 @@ end subroutine
 
 // Fundamental types
 %typemap(in, noblock=1) FORTRAN_INTRINSIC_TYPE {
-  $1 = %static_cast(*$input, $1_ltype);
+  $1 = ($1_ltype)(*$input);
 }
 %typemap(out, noblock=1) FORTRAN_INTRINSIC_TYPE {
-  $result = %static_cast($1, $1_ltype);
+  $result = ($1_ltype)($1);
 }
 %typemap(fin) FORTRAN_INTRINSIC_TYPE
   "$1 = $input"
@@ -176,38 +163,23 @@ end subroutine
 
 // Mutable references are passed by pointers as arguments, but they're
 // *returned* as actual pointers (becoming Fortran pointers).
-%typemap(ctype) FORTRAN_INTRINSIC_TYPE*
+%typemap(ctype) FORTRAN_INTRINSIC_TYPE&
   "$typemap(ctype, $*1_ltype)*"
-%typemap(imtype, in="type(C_PTR), value") FORTRAN_INTRINSIC_TYPE*
+%typemap(imtype, in="type(C_PTR), value") FORTRAN_INTRINSIC_TYPE&
   "type(C_PTR)"
-%typemap(ftype, in="$typemap(ftype, $*1_ltype), target, intent(inout)") FORTRAN_INTRINSIC_TYPE*
+%typemap(ftype, in="$typemap(ftype, $*1_ltype), target, intent(inout)") FORTRAN_INTRINSIC_TYPE&
   "$typemap(ftype, $*1_ltype), pointer"
-%typemap(bindc, in="$typemap(imtype, $*1_ltype)") FORTRAN_INTRINSIC_TYPE*
+%typemap(bindc, in="$typemap(imtype, $*1_ltype)") FORTRAN_INTRINSIC_TYPE&
   "type(C_PTR)"
-%typemap(in, noblock=1) FORTRAN_INTRINSIC_TYPE* {
-   $1 = %reinterpret_cast($input, $1_ltype);
+%typemap(in, noblock=1) FORTRAN_INTRINSIC_TYPE& {
+   $1 = ($1_ltype)($input);
 }
-%typemap(out) FORTRAN_INTRINSIC_TYPE*
+%typemap(out) FORTRAN_INTRINSIC_TYPE&
   "$result = $1;"
-%typemap(fin) FORTRAN_INTRINSIC_TYPE*
+%typemap(fin) FORTRAN_INTRINSIC_TYPE&
   "$1 = c_loc($input)"
-%typemap(fout) FORTRAN_INTRINSIC_TYPE*
+%typemap(fout) FORTRAN_INTRINSIC_TYPE&
   "call c_f_pointer($1, $result)"
-
-%apply FORTRAN_INTRINSIC_TYPE* { const FORTRAN_INTRINSIC_TYPE* };
-%typemap(ctype) const FORTRAN_INTRINSIC_TYPE*
-  "const $typemap(ctype, $*1_ltype)*"
-%typemap(bindc, in="$typemap(imtype, $*1_ltype), intent(in)") const FORTRAN_INTRINSIC_TYPE*
-  "type(C_PTR)"
-%typemap(in, noblock=1) const FORTRAN_INTRINSIC_TYPE* {
-  $1 = %const_cast($input, $1_ltype);
-}
-%typemap(out, noblock=1) const FORTRAN_INTRINSIC_TYPE* {
-  $result = %const_cast($1, $1_ltype);
-}
-
-// Mutable references are treated as mutable pointers
-%apply FORTRAN_INTRINSIC_TYPE* { FORTRAN_INTRINSIC_TYPE& }
 
 // We treat const references as values for fundamental types
 // Since ctype/imtype/ftype aren't defined for 'FORTRAN_INTRINSIC_TYPE' (just for each fundamental type), use $typemap to retrieve the corresponding values.
@@ -219,25 +191,14 @@ end subroutine
 %typemap(ftype, in="$typemap(ftype, $*1_ltype), intent(in)" ) const FORTRAN_INTRINSIC_TYPE&
   "$typemap(ftype, $*1_ltype)"
 %typemap(in, noblock=1) const FORTRAN_INTRINSIC_TYPE& ($*1_ltype temp) {
-  temp = %static_cast(*$input, $*1_ltype);
+  temp = ($*1_ltype)(*$input);
   $1 = &temp;
 }
 %typemap(out) const FORTRAN_INTRINSIC_TYPE& 
   "$result = *$1;"
 
-// Treat rvalue references as values
+// Treat rvalue references as const refrerences
 %apply const FORTRAN_INTRINSIC_TYPE& { FORTRAN_INTRINSIC_TYPE&& };
-
-// Const references to mutable pointers
-%apply FORTRAN_INTRINSIC_TYPE* { FORTRAN_INTRINSIC_TYPE *const & };
-%typemap(in, noblock=1) FORTRAN_INTRINSIC_TYPE *const & ($*1_ltype temp)
-  {temp = %const_cast($input, $*1_ltype);
-   $1 = &temp;}
-%typemap(out) FORTRAN_INTRINSIC_TYPE *const &
-  "$result = *$1;"
-  
-// Const references to const pointers
-%apply const FORTRAN_INTRINSIC_TYPE* { const FORTRAN_INTRINSIC_TYPE *const & };
 
 /* -------------------------------------------------------------------------
  * ARRAY TYPES
@@ -256,11 +217,9 @@ end subroutine
  * ------------------------------------------------------------------------- */
 
 %fortran_apply_typemaps(FORTRAN_INTRINSIC_TYPE, FORTRAN_UNSIGNED_TYPE)
-%typemap(in, noblock=1) const FORTRAN_UNSIGNED_TYPE* {
+%typemap(in, noblock=1) const FORTRAN_UNSIGNED_TYPE& {
    $1 = ($1_ltype)($input);
 }
-%apply FORTRAN_UNSIGNED_TYPE* { FORTRAN_UNSIGNED_TYPE& };
-%apply const FORTRAN_UNSIGNED_TYPE* { const FORTRAN_UNSIGNED_TYPE& };
 
 /* -------------------------------------------------------------------------
  * VOID TYPES
@@ -280,37 +239,7 @@ end subroutine
  * A generic C pointer is treated as a value.
  * ------------------------------------------------------------------------- */
 
-%apply FORTRAN_INTRINSIC_TYPE* { void* } ;
-
-%typemap(ctype) void*
-  "void*"
-%typemap(imtype) void* = FORTRAN_INTRINSIC_TYPE*;
-%typemap(ftype) void*
-  "type(C_PTR)"
-%typemap(bindc, in="type(C_PTR), value") void*
-  "type(C_PTR)"
-
-%typemap(in, noblock=1) void* {
-  $1 = ($1_ltype)($input);
-}
-%typemap(fin) void* = FORTRAN_INTRINSIC_TYPE;
-%typemap(fout) void* = FORTRAN_INTRINSIC_TYPE;
-
-/* -------------------------------------------------------------------------
- * HANDLES
- *
- * A 'void**' looks like a FORTRAN_INTRINSIC_TYPE* where FORTRAN_INTRINSIC_TYPE is 'void*' (aka C_PTR)
- * ------------------------------------------------------------------------- */
-
-%apply void* { void** };
-%typemap(ftype, in="type(C_PTR), target, intent(inout)") void**
-  "type(C_PTR), pointer"
-%typemap(fin) void** = FORTRAN_INTRINSIC_TYPE*;
-%typemap(fout) void** = FORTRAN_INTRINSIC_TYPE*;
-%apply void** { void*&, void *const* };
-
-%typemap(ftype, in="type(C_PTR), target, intent(in)") const void**
-  "type(C_PTR), pointer"
+%fortran_intrinsic(void*, type(C_PTR))
 
 /* -------------------------------------------------------------------------
  * FUNDAMENTAL TYPES
@@ -388,15 +317,6 @@ end subroutine
   "type(C_FUNPTR)"
 
 %apply SWIGTYPE (*)(ANY) { SWIGTYPE (* const)(ANY) } ;
-
-/* -------------------------------------------------------------------------
- * FUNCTION POINTERS
- * ------------------------------------------------------------------------- */
-
-%apply void** { SWIGTYPE (**)(ANY) } ;
-
-%typemap(ftype, in="type(C_FUNPTR), target, intent(inout)") SWIGTYPE (**)(ANY)
-  "type(C_FUNPTR), pointer"
 
 /* -------------------------------------------------------------------------
  * TYPE CHECKING

--- a/Lib/fortran/fundamental.swg
+++ b/Lib/fortran/fundamental.swg
@@ -229,12 +229,30 @@ end subroutine
 // Fixed-sized arrays can be treated natively with Fortran size
 %apply FORTRAN_INTRINSIC_TYPE* { FORTRAN_INTRINSIC_TYPE[ANY], FORTRAN_INTRINSIC_TYPE[ANY][ANY], FORTRAN_INTRINSIC_TYPE[ANY][ANY][ANY] }
 
-%typemap(ftype, checkdim=1, noblock=1) FORTRAN_INTRINSIC_TYPE[ANY]
- {$typemap(imtype, $1_basetype), dimension($1_dim0)}
-%typemap(ftype, checkdim=1, noblock=1) FORTRAN_INTRINSIC_TYPE[ANY][ANY]
- {$typemap(imtype, $1_basetype), dimension($1_dim1,$1_dim0)}
-%typemap(ftype, checkdim=1, noblock=1) FORTRAN_INTRINSIC_TYPE[ANY][ANY][ANY]
- {$typemap(imtype, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0)}
+%typemap(ftype, in="$typemap(ftype, $1_basetype), dimension($1_dim0), target", checkdim=1) FORTRAN_INTRINSIC_TYPE[ANY]
+ "$typemap(ftype, $1_basetype), dimension($1_dim0)"
+%typemap(ftype, in="$typemap(ftype, $1_basetype), dimension($1_dim1,$1_dim0), target", checkdim=1) FORTRAN_INTRINSIC_TYPE[ANY][ANY]
+ "$typemap(ftype, $1_basetype), dimension($1_dim1,$1_dim0)"
+%typemap(ftype, in="$typemap(ftype, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0), target", checkdim=1) FORTRAN_INTRINSIC_TYPE[ANY][ANY][ANY]
+ "$typemap(ftype, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0)"
+
+%typemap(fout, temp="$typemap(ftype, $1_basetype), dimension(:), pointer", checkdim=1, noblock=1) FORTRAN_INTRINSIC_TYPE[ANY]
+{call c_f_pointer($1, $1_temp, [$1_dim0])
+$result = $1_temp}
+%typemap(fout, temp="$typemap(ftype, $1_basetype), dimension(:,:), pointer", checkdim=1, noblock=1) FORTRAN_INTRINSIC_TYPE[ANY][ANY]
+{call c_f_pointer($1, $1_temp, [$1_dim1,$1_dim0])
+$result = $1_temp}
+%typemap(fout, temp="$typemap(ftype, $1_basetype), dimension(:,:,:), pointer", checkdim=1, noblock=1) FORTRAN_INTRINSIC_TYPE[ANY][ANY][ANY]
+{call c_f_pointer($1, $1_temp, [$1_dim2,$1_dim1,$1_dim0])
+$result = $1_temp}
+
+// Generic array types with unknown dimensions for C binding
+%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim0), target", checkdim=1) FORTRAN_INTRINSIC_TYPE[ANY]
+ "$typemap(bindc, $1_basetype), dimension($1_dim0)"
+%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim1,$1_dim0), target", checkdim=1) FORTRAN_INTRINSIC_TYPE[ANY][ANY]
+ "$typemap(bindc, $1_basetype), dimension($1_dim1,$1_dim0)"
+%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0), target", checkdim=1) FORTRAN_INTRINSIC_TYPE[ANY][ANY][ANY]
+ "$typemap(bindc, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0)"
 
 // Treat rvalue references as values
 %apply const FORTRAN_INTRINSIC_TYPE& { FORTRAN_INTRINSIC_TYPE&& };
@@ -255,12 +273,12 @@ end subroutine
  * ------------------------------------------------------------------------- */
 
 // Generic array types with unknown dimensions for C binding
-%typemap(bindc, checkdim=1, noblock=1) SWIGTYPE[ANY]
- {$typemap(imtype, $1_basetype), dimension($1_dim0)}
-%typemap(bindc, checkdim=1, noblock=1) SWIGTYPE[ANY][ANY]
- {$typemap(imtype, $1_basetype), dimension($1_dim1,$1_dim0)}
-%typemap(bindc, checkdim=1, noblock=1) SWIGTYPE[ANY][ANY][ANY]
- {$typemap(imtype, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0)}
+%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim0), target", checkdim=1) SWIGTYPE[ANY]
+ "$typemap(bindc, $1_basetype), dimension($1_dim0)"
+%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim1,$1_dim0), target", checkdim=1) SWIGTYPE[ANY][ANY]
+ "$typemap(bindc, $1_basetype), dimension($1_dim1,$1_dim0)"
+%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0), target", checkdim=1) SWIGTYPE[ANY][ANY][ANY]
+ "$typemap(bindc, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0)"
 
 /* -------------------------------------------------------------------------
  * UNSIGNED FUNDAMENTAL TYPE

--- a/Lib/fortran/fundamental.swg
+++ b/Lib/fortran/fundamental.swg
@@ -82,9 +82,6 @@ end subroutine
   %apply SRCTYPE[ANY]           { DSTTYPE[ANY] };
   %apply SRCTYPE[ANY][ANY]      { DSTTYPE[ANY][ANY] };
   %apply SRCTYPE[ANY][ANY][ANY] { DSTTYPE[ANY][ANY][ANY] };
-  %apply SRCTYPE[]              { DSTTYPE[] };
-  %apply SRCTYPE[][ANY]         { DSTTYPE[][ANY] };
-  %apply SRCTYPE[][ANY][ANY]    { DSTTYPE[][ANY][ANY] };
   %apply SRCTYPE* const&        { DSTTYPE* const& };
   %apply SRCTYPE&&              { DSTTYPE&& };
 
@@ -135,8 +132,8 @@ end subroutine
   %fortran_apply_typemaps(FORTRAN_UNSIGNED_TYPE, DSTTYPE)
 
   %typemap(out, noblock=1)
-    DSTTYPE*, DSTTYPE&, DSTTYPE[], DSTTYPE[ANY],
-    const DSTTYPE*, const DSTTYPE&, const DSTTYPE[], const DSTTYPE[ANY] {
+    DSTTYPE*, DSTTYPE&, DSTTYPE[ANY],
+    const DSTTYPE*, const DSTTYPE&, const DSTTYPE[ANY] {
      $result = %reinterpret_cast($1, SRCTYPE*);
   }
 %enddef
@@ -231,26 +228,6 @@ end subroutine
 %typemap(out) const FORTRAN_INTRINSIC_TYPE& 
   "$result = *$1;"
 
-// Fixed-sized arrays can be treated natively with Fortran size
-%apply FORTRAN_INTRINSIC_TYPE* { FORTRAN_INTRINSIC_TYPE[ANY], FORTRAN_INTRINSIC_TYPE[ANY][ANY], FORTRAN_INTRINSIC_TYPE[ANY][ANY][ANY] }
-
-%typemap(ftype, in="$typemap(ftype, $1_basetype), dimension($1_dim0), target", checkdim=1) FORTRAN_INTRINSIC_TYPE[ANY]
- "$typemap(ftype, $1_basetype), dimension($1_dim0)"
-%typemap(ftype, in="$typemap(ftype, $1_basetype), dimension($1_dim1,$1_dim0), target", checkdim=1) FORTRAN_INTRINSIC_TYPE[ANY][ANY]
- "$typemap(ftype, $1_basetype), dimension($1_dim1,$1_dim0)"
-%typemap(ftype, in="$typemap(ftype, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0), target", checkdim=1) FORTRAN_INTRINSIC_TYPE[ANY][ANY][ANY]
- "$typemap(ftype, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0)"
-
-%typemap(fout, temp="$typemap(ftype, $1_basetype), dimension(:), pointer", checkdim=1, noblock=1) FORTRAN_INTRINSIC_TYPE[ANY]
-{call c_f_pointer($1, $1_temp, [$1_dim0])
-$result = $1_temp}
-%typemap(fout, temp="$typemap(ftype, $1_basetype), dimension(:,:), pointer", checkdim=1, noblock=1) FORTRAN_INTRINSIC_TYPE[ANY][ANY]
-{call c_f_pointer($1, $1_temp, [$1_dim1,$1_dim0])
-$result = $1_temp}
-%typemap(fout, temp="$typemap(ftype, $1_basetype), dimension(:,:,:), pointer", checkdim=1, noblock=1) FORTRAN_INTRINSIC_TYPE[ANY][ANY][ANY]
-{call c_f_pointer($1, $1_temp, [$1_dim2,$1_dim1,$1_dim0])
-$result = $1_temp}
-
 // Generic array types with unknown dimensions for C binding
 %typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim0), target", checkdim=1) FORTRAN_INTRINSIC_TYPE[ANY]
  "$typemap(bindc, $1_basetype), dimension($1_dim0)"
@@ -258,9 +235,6 @@ $result = $1_temp}
  "$typemap(bindc, $1_basetype), dimension($1_dim1,$1_dim0)"
 %typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0), target", checkdim=1) FORTRAN_INTRINSIC_TYPE[ANY][ANY][ANY]
  "$typemap(bindc, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0)"
-
-// For array *return* values with unspecified dimension: we can't know the size so treat it as a pointer
-%apply FORTRAN_INTRINSIC_TYPE* { FORTRAN_INTRINSIC_TYPE[], FORTRAN_INTRINSIC_TYPE[][ANY], FORTRAN_INTRINSIC_TYPE[][ANY][ANY] }
 
 // Treat rvalue references as values
 %apply const FORTRAN_INTRINSIC_TYPE& { FORTRAN_INTRINSIC_TYPE&& };

--- a/Lib/fortran/fundamental.swg
+++ b/Lib/fortran/fundamental.swg
@@ -71,21 +71,21 @@ end subroutine
 
 /*!
  * \def %fortran_apply_typemaps
- * \brief Copy fundamental typemaps to the given type.
+ * \brief Copy *fundamental* typemaps to the given type.
  */
 %define %fortran_apply_typemaps(SRCTYPE, DSTTYPE)
   // Copy all relevant typemaps
-  %apply       SRCTYPE*        {       DSTTYPE* };
+  %apply SRCTYPE*               { DSTTYPE* };
+  %apply SRCTYPE&               { DSTTYPE& };
+  %apply SRCTYPE[ANY]           { DSTTYPE[ANY] };
+  %apply SRCTYPE[ANY][ANY]      { DSTTYPE[ANY][ANY] };
+  %apply SRCTYPE[ANY][ANY][ANY] { DSTTYPE[ANY][ANY][ANY] };
+  %apply SRCTYPE* const&        { DSTTYPE* const& };
+  %apply SRCTYPE&&              { DSTTYPE&& };
+
   %apply const SRCTYPE*        { const DSTTYPE* };
-  %apply       SRCTYPE&        {       DSTTYPE& };
   %apply const SRCTYPE&        { const DSTTYPE& };
-  %apply       SRCTYPE[]       {       DSTTYPE[] };
-  %apply const SRCTYPE[]       { const DSTTYPE[] };
-  %apply       SRCTYPE[ANY]    {       DSTTYPE[ANY] };
-  %apply const SRCTYPE[ANY]    { const DSTTYPE[ANY] };
-  %apply       SRCTYPE* const& {       DSTTYPE* const& };
   %apply const SRCTYPE* const& { const DSTTYPE* const& };
-  %apply       SRCTYPE&&       {       DSTTYPE&&};
 %enddef
 
 /*!
@@ -109,15 +109,16 @@ end subroutine
   %typemap(fin) CTYPE = FORTRAN_INTRINSIC_TYPE;
   %typemap(fout) CTYPE = FORTRAN_INTRINSIC_TYPE;
 
-  // XXX I'd like to do this as FORTRAN_INTRINSIC_TYPE, but because $1_basetype doesn't work as expected, and there's no way to do `$**1_ltype`, we have to explicitly add
-  // these here.
+  %typemap(fin) CTYPE = FORTRAN_INTRINSIC_TYPE;
+  %typemap(fout) CTYPE = FORTRAN_INTRINSIC_TYPE;
+
   %typemap(ftype, in={FTYPE, target, intent(inout)}, noblock=1) CTYPE *const & {
     FTYPE, pointer
   }
   %typemap(ctype, noblock=1) CTYPE *const & {
     const CTYPE*
   }
-  %apply CTYPE *const & { const CTYPE *const & };
+
 %enddef
 
 /*!
@@ -133,19 +134,6 @@ end subroutine
     const DSTTYPE*, const DSTTYPE&, const DSTTYPE[], const DSTTYPE[ANY] {
      $result = %reinterpret_cast($1, SRCTYPE*);
   }
-%enddef
-
-/*!
- * \def %fortran_bindc_array
- * \brief Generate array typemaps for the given dimensions
- */
-%define %fortran_bindc_array(CPPTYPE, FDIMS...)
-  #define FARRTYPE $typemap(imtype, $1_basetype), FDIMS
-  %typemap(bindc, in={FARRTYPE, intent(inout)}, checkdim=1, noblock=1) CPPTYPE
-   {FARRTYPE}
-  %typemap(bindc, in={FARRTYPE, intent(in)}, checkdim=1, noblock=1) const CPPTYPE
-   {FARRTYPE}
-  #undef FARRTYPE
 %enddef
 
 /* -------------------------------------------------------------------------
@@ -238,34 +226,16 @@ end subroutine
 %typemap(out) const FORTRAN_INTRINSIC_TYPE& 
   "$result = *$1;"
 
-// Unspecified-size array inputs should appear as deferred arrays; but since we can't provide a size for the output, we assign a size of 1 for now.
-%apply FORTRAN_INTRINSIC_TYPE* { FORTRAN_INTRINSIC_TYPE[] }
-%typemap(ftype, in="$typemap(ftype, $*1_ltype), dimension(*), target, intent(inout)", checkdim=1) FORTRAN_INTRINSIC_TYPE[]
-  "$typemap(ftype, $*1_ltype), dimension(:), pointer"
-%typemap(fin, checkdim=1) FORTRAN_INTRINSIC_TYPE[]
-  "$1 = c_loc($input(1))" // (1): see fortranarray.swg
-%typemap(fout, checkdim=1) FORTRAN_INTRINSIC_TYPE[]
-  "call c_f_pointer($1, $result, [1])"
- 
-%apply const FORTRAN_INTRINSIC_TYPE* { const FORTRAN_INTRINSIC_TYPE[] }
-%typemap(ftype, in="$typemap(ftype, $*1_ltype), dimension(*), target, intent(in)", checkdim=1) const FORTRAN_INTRINSIC_TYPE[]
-  "$typemap(ftype, $*1_ltype), dimension(:), pointer"
-%typemap(fin) const FORTRAN_INTRINSIC_TYPE[] = FORTRAN_INTRINSIC_TYPE[];
-%typemap(fout) const FORTRAN_INTRINSIC_TYPE[] = FORTRAN_INTRINSIC_TYPE[];
-  
-// Fixed-sized arrays can be treated natively
-%apply FORTRAN_INTRINSIC_TYPE[] { FORTRAN_INTRINSIC_TYPE[ANY] }
-%typemap(ftype, in="$typemap(ftype, $*1_ltype), dimension($1_dim0), target, intent(inout)", checkdim=1) FORTRAN_INTRINSIC_TYPE[ANY]
-  "$typemap(ftype, $*1_ltype), dimension(:), pointer"
-%typemap(fout, checkdim=1) FORTRAN_INTRINSIC_TYPE[ANY]
-  "call c_f_pointer($1, $result, [$1_dim0])"
+// Fixed-sized arrays can be treated natively with Fortran size
+%apply FORTRAN_INTRINSIC_TYPE* { FORTRAN_INTRINSIC_TYPE[ANY], FORTRAN_INTRINSIC_TYPE[ANY][ANY], FORTRAN_INTRINSIC_TYPE[ANY][ANY][ANY] }
 
-// Use correct intent for const fixed-size arrays
-%apply const FORTRAN_INTRINSIC_TYPE[] { const FORTRAN_INTRINSIC_TYPE[ANY] }
-%typemap(ftype, in="$typemap(ftype, $*1_ltype), dimension($1_dim0), target, intent(in)", checkdim=1) const FORTRAN_INTRINSIC_TYPE[ANY]
-  "$typemap(ftype, $*1_ltype), dimension(:), pointer"
-%typemap(fout) const FORTRAN_INTRINSIC_TYPE[ANY] = FORTRAN_INTRINSIC_TYPE[ANY];
-  
+%typemap(ftype, checkdim=1, noblock=1) FORTRAN_INTRINSIC_TYPE[ANY]
+ {$typemap(imtype, $1_basetype), dimension($1_dim0)}
+%typemap(ftype, checkdim=1, noblock=1) FORTRAN_INTRINSIC_TYPE[ANY][ANY]
+ {$typemap(imtype, $1_basetype), dimension($1_dim1,$1_dim0)}
+%typemap(ftype, checkdim=1, noblock=1) FORTRAN_INTRINSIC_TYPE[ANY][ANY][ANY]
+ {$typemap(imtype, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0)}
+
 // Treat rvalue references as values
 %apply const FORTRAN_INTRINSIC_TYPE& { FORTRAN_INTRINSIC_TYPE&& };
 
@@ -285,10 +255,12 @@ end subroutine
  * ------------------------------------------------------------------------- */
 
 // Generic array types with unknown dimensions for C binding
-%fortran_bindc_array(FORTRAN_INTRINSIC_TYPE[],           dimension(*))
-%fortran_bindc_array(FORTRAN_INTRINSIC_TYPE[ANY],        dimension($1_dim0))
-%fortran_bindc_array(SWIGTYPE[][ANY],      dimension($1_dim1,*))
-%fortran_bindc_array(SWIGTYPE[][ANY][ANY], dimension($1_dim2,$1_dim1,*)) 
+%typemap(bindc, checkdim=1, noblock=1) SWIGTYPE[ANY]
+ {$typemap(imtype, $1_basetype), dimension($1_dim0)}
+%typemap(bindc, checkdim=1, noblock=1) SWIGTYPE[ANY][ANY]
+ {$typemap(imtype, $1_basetype), dimension($1_dim1,$1_dim0)}
+%typemap(bindc, checkdim=1, noblock=1) SWIGTYPE[ANY][ANY][ANY]
+ {$typemap(imtype, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0)}
 
 /* -------------------------------------------------------------------------
  * UNSIGNED FUNDAMENTAL TYPE

--- a/Lib/fortran/fundamental.swg
+++ b/Lib/fortran/fundamental.swg
@@ -120,9 +120,7 @@ end subroutine
   %apply SRCTYPE { DSTTYPE };
   %fortran_apply_typemaps(FORTRAN_UNSIGNED_TYPE, DSTTYPE)
 
-  %typemap(out, noblock=1)
-    DSTTYPE*, DSTTYPE&,
-    const DSTTYPE*, const DSTTYPE& {
+  %typemap(out, noblock=1) DSTTYPE&, const DSTTYPE& {
      $result = (SRCTYPE*)($1);
   }
 %enddef

--- a/Lib/fortran/fundamental.swg
+++ b/Lib/fortran/fundamental.swg
@@ -120,7 +120,7 @@ end subroutine
   %apply SRCTYPE { DSTTYPE };
   %fortran_apply_typemaps(FORTRAN_UNSIGNED_TYPE, DSTTYPE)
 
-  %typemap(out, noblock=1) DSTTYPE&, const DSTTYPE& {
+  %typemap(out, noblock=1) DSTTYPE& {
      $result = (SRCTYPE*)($1);
   }
 %enddef

--- a/Lib/fortran/fundamental.swg
+++ b/Lib/fortran/fundamental.swg
@@ -72,6 +72,8 @@ end subroutine
 /*!
  * \def %fortran_apply_typemaps
  * \brief Copy *fundamental* typemaps to the given type.
+ *
+ * These should be exactly the typemaps declared as FORTRAN_INTRINSIC_TYPE. 
  */
 %define %fortran_apply_typemaps(SRCTYPE, DSTTYPE)
   // Copy all relevant typemaps
@@ -80,6 +82,9 @@ end subroutine
   %apply SRCTYPE[ANY]           { DSTTYPE[ANY] };
   %apply SRCTYPE[ANY][ANY]      { DSTTYPE[ANY][ANY] };
   %apply SRCTYPE[ANY][ANY][ANY] { DSTTYPE[ANY][ANY][ANY] };
+  %apply SRCTYPE[]              { DSTTYPE[] };
+  %apply SRCTYPE[][ANY]         { DSTTYPE[][ANY] };
+  %apply SRCTYPE[][ANY][ANY]    { DSTTYPE[][ANY][ANY] };
   %apply SRCTYPE* const&        { DSTTYPE* const& };
   %apply SRCTYPE&&              { DSTTYPE&& };
 
@@ -122,10 +127,10 @@ end subroutine
 %enddef
 
 /*!
- * \def %fortran_apply_unsigned
+ * \def %fortran_unsigned
  * \brief Apply typemaps for treating signed/unsigned variables
  */
-%define %fortran_apply_unsigned(SRCTYPE, DSTTYPE)
+%define %fortran_unsigned(SRCTYPE, DSTTYPE)
   %apply SRCTYPE { DSTTYPE };
   %fortran_apply_typemaps(FORTRAN_UNSIGNED_TYPE, DSTTYPE)
 
@@ -254,6 +259,9 @@ $result = $1_temp}
 %typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0), target", checkdim=1) FORTRAN_INTRINSIC_TYPE[ANY][ANY][ANY]
  "$typemap(bindc, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0)"
 
+// For array *return* values with unspecified dimension: we can't know the size so treat it as a pointer
+%apply FORTRAN_INTRINSIC_TYPE* { FORTRAN_INTRINSIC_TYPE[], FORTRAN_INTRINSIC_TYPE[][ANY], FORTRAN_INTRINSIC_TYPE[][ANY][ANY] }
+
 // Treat rvalue references as values
 %apply const FORTRAN_INTRINSIC_TYPE& { FORTRAN_INTRINSIC_TYPE&& };
 
@@ -367,13 +375,11 @@ void ** const, void **const &};
 %fortran_intrinsic(char       , character(C_CHAR)     )
 
 // Unsigned integer types
-%fortran_apply_unsigned(signed char     ,unsigned char      )
-%fortran_apply_unsigned(signed short    ,unsigned short     )
-%fortran_apply_unsigned(signed int      ,unsigned int       )
-%fortran_apply_unsigned(signed long     ,unsigned long      )
-%fortran_apply_unsigned(signed long long,unsigned long long )
-
-// TODO: provide optional typemap(check) code for unsigned/signed range
+%fortran_unsigned(signed char     ,unsigned char      )
+%fortran_unsigned(signed short    ,unsigned short     )
+%fortran_unsigned(signed int      ,unsigned int       )
+%fortran_unsigned(signed long     ,unsigned long      )
+%fortran_unsigned(signed long long,unsigned long long )
 
 /* -------------------------------------------------------------------------
  * LOGICAL (BOOLEAN) TYPE

--- a/Lib/fortran/fundamental.swg
+++ b/Lib/fortran/fundamental.swg
@@ -79,9 +79,6 @@ end subroutine
   // Copy all relevant typemaps
   %apply SRCTYPE*               { DSTTYPE* };
   %apply SRCTYPE&               { DSTTYPE& };
-  %apply SRCTYPE[ANY]           { DSTTYPE[ANY] };
-  %apply SRCTYPE[ANY][ANY]      { DSTTYPE[ANY][ANY] };
-  %apply SRCTYPE[ANY][ANY][ANY] { DSTTYPE[ANY][ANY][ANY] };
   %apply SRCTYPE* const&        { DSTTYPE* const& };
   %apply SRCTYPE&&              { DSTTYPE&& };
 
@@ -132,8 +129,8 @@ end subroutine
   %fortran_apply_typemaps(FORTRAN_UNSIGNED_TYPE, DSTTYPE)
 
   %typemap(out, noblock=1)
-    DSTTYPE*, DSTTYPE&, DSTTYPE[ANY],
-    const DSTTYPE*, const DSTTYPE&, const DSTTYPE[ANY] {
+    DSTTYPE*, DSTTYPE&,
+    const DSTTYPE*, const DSTTYPE& {
      $result = %reinterpret_cast($1, SRCTYPE*);
   }
 %enddef
@@ -228,14 +225,6 @@ end subroutine
 %typemap(out) const FORTRAN_INTRINSIC_TYPE& 
   "$result = *$1;"
 
-// Generic array types with unknown dimensions for C binding
-%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim0), target", checkdim=1) FORTRAN_INTRINSIC_TYPE[ANY]
- "$typemap(bindc, $1_basetype), dimension($1_dim0)"
-%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim1,$1_dim0), target", checkdim=1) FORTRAN_INTRINSIC_TYPE[ANY][ANY]
- "$typemap(bindc, $1_basetype), dimension($1_dim1,$1_dim0)"
-%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0), target", checkdim=1) FORTRAN_INTRINSIC_TYPE[ANY][ANY][ANY]
- "$typemap(bindc, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0)"
-
 // Treat rvalue references as values
 %apply const FORTRAN_INTRINSIC_TYPE& { FORTRAN_INTRINSIC_TYPE&& };
 
@@ -254,7 +243,7 @@ end subroutine
  * ARRAY TYPES
  * ------------------------------------------------------------------------- */
 
-// Generic array types with unknown dimensions for C binding
+// Generic array types with known dimensions for C binding
 %typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim0), target", checkdim=1) SWIGTYPE[ANY]
  "$typemap(bindc, $1_basetype), dimension($1_dim0)"
 %typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim1,$1_dim0), target", checkdim=1) SWIGTYPE[ANY][ANY]
@@ -302,15 +291,10 @@ end subroutine
   "type(C_PTR)"
 
 %typemap(in, noblock=1) void* {
-  $1 = %reinterpret_cast($input, $1_ltype);
+  $1 = ($1_ltype)($input);
 }
 %typemap(fin) void* = FORTRAN_INTRINSIC_TYPE;
 %typemap(fout) void* = FORTRAN_INTRINSIC_TYPE;
-
-%apply void* { const void* } ;
-%typemap(in, noblock=1) const void* {
-  $1 = ($1_ltype)($input);
-}
 
 /* -------------------------------------------------------------------------
  * HANDLES
@@ -325,13 +309,8 @@ end subroutine
 %typemap(fout) void** = FORTRAN_INTRINSIC_TYPE*;
 %apply void** { void*&, void *const* };
 
-%apply const void* { const void** };
 %typemap(ftype, in="type(C_PTR), target, intent(in)") const void**
   "type(C_PTR), pointer"
-%typemap(fin) const void** = const FORTRAN_INTRINSIC_TYPE*;
-%typemap(fout) const void** = const FORTRAN_INTRINSIC_TYPE*;
-%apply const void** { const void*&, const void *const*,
-void ** const, void **const &};
 
 /* -------------------------------------------------------------------------
  * FUNDAMENTAL TYPES
@@ -370,16 +349,16 @@ void ** const, void **const &};
  * ------------------------------------------------------------------------- */
 // Treat bools like integers for C/IM types
 %apply int { bool };
+%typemap(in) bool
+  "$1 = (*$input ? true : false);"
+%typemap(out) bool
+  "$result = ($1 ? 1 : 0);"
 %typemap(ftype, in="logical, intent(in)") bool
   "logical"
 %typemap(bindc, in="logical(C_BOOL), value") bool
   "logical(C_BOOL)"
 
-%typemap(in) bool
-  "$1 = (*$input ? true : false);"
-%typemap(out) bool
-  "$result = ($1 ? 1 : 0);"
-
+// Special Fortran conversions for logical->c_int
 %fortran_typemap_finout(bool)
 
 // Treat const references like values
@@ -391,7 +370,7 @@ void ** const, void **const &};
 }
 
 // Mutable references and arrays are treated like opaque pointers
-%apply void* { bool*, bool& };
+%apply SWIGTYPE* { bool*, bool& };
 
 /* -------------------------------------------------------------------------
  * FUNCTION POINTERS

--- a/Lib/fortran/fundamental.swg
+++ b/Lib/fortran/fundamental.swg
@@ -80,6 +80,11 @@ end subroutine
   %apply SRCTYPE&       { DSTTYPE& };
   %apply SRCTYPE&&      { DSTTYPE&& };
   %apply const SRCTYPE& { const DSTTYPE& };
+
+  // Special bind-c types
+  %typemap(bindc) DSTTYPE[ANY] = SRCTYPE[ANY];
+  %typemap(bindc) DSTTYPE[ANY][ANY] = SRCTYPE[ANY][ANY];
+  %typemap(bindc) DSTTYPE[ANY][ANY][ANY] = SRCTYPE[ANY][ANY][ANY];
 %enddef
 
 /*!
@@ -205,11 +210,11 @@ end subroutine
  * ------------------------------------------------------------------------- */
 
 // Generic array types with known dimensions for C binding
-%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim0), target", checkdim=1) SWIGTYPE[ANY]
+%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim0), target", checkdim=1) FORTRAN_INTRINSIC_TYPE[ANY]
  "$typemap(bindc, $1_basetype), dimension($1_dim0)"
-%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim1,$1_dim0), target", checkdim=1) SWIGTYPE[ANY][ANY]
+%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim1,$1_dim0), target", checkdim=1) FORTRAN_INTRINSIC_TYPE[ANY][ANY]
  "$typemap(bindc, $1_basetype), dimension($1_dim1,$1_dim0)"
-%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0), target", checkdim=1) SWIGTYPE[ANY][ANY][ANY]
+%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0), target", checkdim=1) FORTRAN_INTRINSIC_TYPE[ANY][ANY][ANY]
  "$typemap(bindc, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0)"
 
 /* -------------------------------------------------------------------------

--- a/Lib/fortran/typemaps.i
+++ b/Lib/fortran/typemaps.i
@@ -30,3 +30,39 @@ $2 = $input->size;
   $typemap(imtype, $*1_ltype), dimension(:), pointer
 }
 
+/* -------------------------------------------------------------------------
+ * Interact natively with Fortran fixed-size arrays.
+ *
+ * To apply these to a function `void foo(const int x[4]);`:
+ *
+ * %apply ARRAY[ANY] {const  int x[4] };
+ */
+
+%apply FORTRAN_INTRINSIC_TYPE* { ARRAY[ANY], ARRAY[ANY][ANY], ARRAY[ANY][ANY][ANY] }
+
+%typemap(ftype, in="$typemap(ftype, $1_basetype), dimension($1_dim0), target", checkdim=1) ARRAY[ANY]
+ "$typemap(ftype, $1_basetype), dimension($1_dim0)"
+%typemap(ftype, in="$typemap(ftype, $1_basetype), dimension($1_dim1,$1_dim0), target", checkdim=1) ARRAY[ANY][ANY]
+ "$typemap(ftype, $1_basetype), dimension($1_dim1,$1_dim0)"
+%typemap(ftype, in="$typemap(ftype, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0), target", checkdim=1) ARRAY[ANY][ANY][ANY]
+ "$typemap(ftype, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0)"
+
+%typemap(fout, temp="$typemap(ftype, $1_basetype), dimension(:), pointer", checkdim=1, noblock=1) ARRAY[ANY]
+{call c_f_pointer($1, $1_temp, [$1_dim0])
+$result = $1_temp}
+%typemap(fout, temp="$typemap(ftype, $1_basetype), dimension(:,:), pointer", checkdim=1, noblock=1) ARRAY[ANY][ANY]
+{call c_f_pointer($1, $1_temp, [$1_dim1,$1_dim0])
+$result = $1_temp}
+%typemap(fout, temp="$typemap(ftype, $1_basetype), dimension(:,:,:), pointer", checkdim=1, noblock=1) ARRAY[ANY][ANY][ANY]
+{call c_f_pointer($1, $1_temp, [$1_dim2,$1_dim1,$1_dim0])
+$result = $1_temp}
+
+// Generic array types with unknown dimensions for C binding
+%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim0), target", checkdim=1) ARRAY[ANY]
+ "$typemap(bindc, $1_basetype), dimension($1_dim0)"
+%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim1,$1_dim0), target", checkdim=1) ARRAY[ANY][ANY]
+ "$typemap(bindc, $1_basetype), dimension($1_dim1,$1_dim0)"
+%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0), target", checkdim=1) ARRAY[ANY][ANY][ANY]
+ "$typemap(bindc, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0)"
+
+

--- a/Lib/fortran/typemaps.i
+++ b/Lib/fortran/typemaps.i
@@ -35,34 +35,37 @@ $2 = $input->size;
  *
  * To apply these to a function `void foo(const int x[4]);`:
  *
- * %apply ARRAY[ANY] {const  int x[4] };
+ * %apply SWIGTYPE ARRAY[ANY] {const  int x[4] };
  */
 
-%apply FORTRAN_INTRINSIC_TYPE* { ARRAY[ANY], ARRAY[ANY][ANY], ARRAY[ANY][ANY][ANY] }
+%apply FORTRAN_INTRINSIC_TYPE& { SWIGTYPE ARRAY[ANY], SWIGTYPE ARRAY[ANY][ANY], SWIGTYPE ARRAY[ANY][ANY][ANY] }
 
-%typemap(ftype, in="$typemap(ftype, $1_basetype), dimension($1_dim0), target", checkdim=1) ARRAY[ANY]
+%typemap(ftype, in="$typemap(ftype, $1_basetype), dimension($1_dim0), target", checkdim=1) SWIGTYPE ARRAY[ANY]
  "$typemap(ftype, $1_basetype), dimension($1_dim0)"
-%typemap(ftype, in="$typemap(ftype, $1_basetype), dimension($1_dim1,$1_dim0), target", checkdim=1) ARRAY[ANY][ANY]
+%typemap(ftype, in="$typemap(ftype, $1_basetype), dimension($1_dim1,$1_dim0), target", checkdim=1) SWIGTYPE ARRAY[ANY][ANY]
  "$typemap(ftype, $1_basetype), dimension($1_dim1,$1_dim0)"
-%typemap(ftype, in="$typemap(ftype, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0), target", checkdim=1) ARRAY[ANY][ANY][ANY]
+%typemap(ftype, in="$typemap(ftype, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0), target", checkdim=1) SWIGTYPE ARRAY[ANY][ANY][ANY]
  "$typemap(ftype, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0)"
 
-%typemap(fout, temp="$typemap(ftype, $1_basetype), dimension(:), pointer", checkdim=1, noblock=1) ARRAY[ANY]
+%typemap(fout, temp="$typemap(ftype, $1_basetype), dimension(:), pointer", checkdim=1, noblock=1) SWIGTYPE ARRAY[ANY]
 {call c_f_pointer($1, $1_temp, [$1_dim0])
 $result = $1_temp}
-%typemap(fout, temp="$typemap(ftype, $1_basetype), dimension(:,:), pointer", checkdim=1, noblock=1) ARRAY[ANY][ANY]
+%typemap(fout, temp="$typemap(ftype, $1_basetype), dimension(:,:), pointer", checkdim=1, noblock=1) SWIGTYPE ARRAY[ANY][ANY]
 {call c_f_pointer($1, $1_temp, [$1_dim1,$1_dim0])
 $result = $1_temp}
-%typemap(fout, temp="$typemap(ftype, $1_basetype), dimension(:,:,:), pointer", checkdim=1, noblock=1) ARRAY[ANY][ANY][ANY]
+%typemap(fout, temp="$typemap(ftype, $1_basetype), dimension(:,:,:), pointer", checkdim=1, noblock=1) SWIGTYPE ARRAY[ANY][ANY][ANY]
 {call c_f_pointer($1, $1_temp, [$1_dim2,$1_dim1,$1_dim0])
 $result = $1_temp}
 
+%typemap(fin) SWIGTYPE ARRAY[ANY], SWIGTYPE ARRAY[ANY][ANY], SWIGTYPE ARRAY[ANY][ANY][ANY]
+  "$1 = c_loc($input)"
+
 // Generic array types with unknown dimensions for C binding
-%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim0), target", checkdim=1) ARRAY[ANY]
+%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim0), target", checkdim=1) SWIGTYPE ARRAY[ANY]
  "$typemap(bindc, $1_basetype), dimension($1_dim0)"
-%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim1,$1_dim0), target", checkdim=1) ARRAY[ANY][ANY]
+%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim1,$1_dim0), target", checkdim=1) SWIGTYPE ARRAY[ANY][ANY]
  "$typemap(bindc, $1_basetype), dimension($1_dim1,$1_dim0)"
-%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0), target", checkdim=1) ARRAY[ANY][ANY][ANY]
+%typemap(bindc, in="$typemap(bindc, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0), target", checkdim=1) SWIGTYPE ARRAY[ANY][ANY][ANY]
  "$typemap(bindc, $1_basetype), dimension($1_dim2,$1_dim1,$1_dim0)"
 
 

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -112,29 +112,33 @@ bool is_fortran_intexpr(String *s) {
 /* -------------------------------------------------------------------------
  * \brief Check a parameter for invalid dimension names.
  */
-bool bad_fortran_dims(Node *n, const char *tmap_name) {
-  bool is_bad = false;
-  // See if the typemap needs its dimensions checked
+int fix_fortran_dims(Node *n, const char *tmap_name, String *typemap) {
   String *key = NewStringf("tmap:%s:checkdim", tmap_name);
-  if (GetFlag(n, key)) {
-    SwigType *t = Getattr(n, "type");
-    if (SwigType_isarray(t)) {
-      int ndim = SwigType_array_ndim(t);
-      for (int i = 0; i < ndim; i++) {
-        String *dim = SwigType_array_getdim(t, i);
-        if (dim && Len(dim) > 0 && !is_fortran_intexpr(dim)) {
-          Swig_warning(WARN_LANG_IDENTIFIER, input_file, line_number,
-                       "Array dimension expression '%s' is incompatible with Fortran\n",
-                       dim);
-          is_bad = true;
-        }
-        Delete(dim);
-      }
+  bool is_checkdims = GetFlag(n, key);
+  Delete(key);
+  if (!is_checkdims)
+    return SWIG_OK;
+  
+  SwigType* t = Getattr(n, "type");
+  ASSERT_OR_PRINT_NODE(SwigType_isarray(t), n);
+  int ndim = SwigType_array_ndim(t);
+  for (int i = 0; i < ndim; i++) {
+    String *dim = SwigType_array_getdim(t, i);
+    if (dim && Len(dim) > 0 && !is_fortran_intexpr(dim)) {
+      Swig_warning(WARN_LANG_IDENTIFIER, input_file, line_number,
+                   "Array dimension expression '%s' is incompatible with Fortran\n",
+                   dim);
+      Delete(dim);
+      return SWIG_ERROR;
     }
+    Delete(dim);
   }
 
-  Delete(key);
-  return is_bad;
+  // Replace empty dimensions with assumed-size dimension
+  Replaceall(typemap, "dimension()", "dimension(*)");
+  Replaceall(typemap, ",)", ",*)");
+
+  return SWIG_OK;
 }
 
 /* -------------------------------------------------------------------------
@@ -1587,15 +1591,12 @@ Wrapper *FORTRAN::imfuncWrapper(Node *n) {
 
     // Add dummy argument to wrapper body
     String *imtype = get_typemap(tmtype, "in", p, warning_flag);
-    String *cpptype = Getattr(p, "type");
-    this->replace_fclassname(cpptype, imtype);
-    Printv(imlocals, "\n   ", imtype, " :: ", imname, NULL);
-
-    // Check for bad dimension parameters
-    if (bad_fortran_dims(p, tmtype)) {
+    if (fix_fortran_dims(p, tmtype, imtype) != SWIG_OK) {
       DelWrapper(imfunc);
       return NULL;
     }
+    this->replace_fclassname(Getattr(p, "type"), imtype);
+    Printv(imlocals, "\n   ", imtype, " :: ", imname, NULL);
 
     // Include import statements if present; needed for actual structs
     // passed into interface code
@@ -1843,7 +1844,6 @@ Wrapper *FORTRAN::proxyfuncWrapper(Node *n) {
   List *fcall_arglist = NewList();
   for (Iterator it = First(cparmlist); it.item; it = Next(it)) {
     Parm *p = it.item;
-    String *cpptype = Getattr(p, "type");
 
     // Add parameter name to declaration list
     String *farg = this->makeParameterName(n, p, i++);
@@ -1870,13 +1870,12 @@ Wrapper *FORTRAN::proxyfuncWrapper(Node *n) {
 
     // Add dummy argument to wrapper body
     String *ftype = get_typemap("ftype", "in", p, WARN_FORTRAN_TYPEMAP_FTYPE_UNDEF);
-    this->replace_fclassname(cpptype, ftype);
-    Printv(fargs, "   ", ftype, " :: ", farg, "\n", NULL);
-
-    if (bad_fortran_dims(p, "ftype")) {
+    if (fix_fortran_dims(p, "ftype", ftype) != SWIG_OK) {
       DelWrapper(ffunc);
       return NULL;
     }
+    this->replace_fclassname(Getattr(p, "type"), ftype);
+    Printv(fargs, "   ", ftype, " :: ", farg, "\n", NULL);
 
     // Add this argument to the intermediate call function
     Append(fcall_arglist, Getattr(p, "imname"));
@@ -1941,10 +1940,6 @@ Wrapper *FORTRAN::proxyfuncWrapper(Node *n) {
   Parm *outparm = NewParm(return_cpptype, Getattr(n, "name"), n);
   Setattr(outparm, "lname", "fresult"); // Replaces $1
   String *fbody = attach_typemap("fout", outparm, WARN_FORTRAN_TYPEMAP_FOUT_UNDEF);
-  if (bad_fortran_dims(outparm, "fout")) {
-    DelWrapper(ffunc);
-    return NULL;
-  }
 
   // Add any needed temporary variables
   if (String *temptype = Getattr(outparm, "tmap:fout:temp")) {
@@ -2797,7 +2792,7 @@ int FORTRAN::constantWrapper(Node *n) {
   }
 
   // Check for incompatible array dimensions
-  if (bad_fortran_dims(n, "bindc")) {
+  if (fix_fortran_dims(n, "bindc", bindc_typestr) != SWIG_OK) {
     return SWIG_NOWRAP;
   }
 

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -110,21 +110,54 @@ bool is_fortran_intexpr(String *s) {
 }
 
 /* -------------------------------------------------------------------------
+ * \brief Replace '.a()' with '.a(*)' to transform C unspecified array dimensions to Fortran 'deferred' array dimensions 
+ */
+void transform_array_type(Node *n) {
+  SwigType *t = Getattr(n, "type");
+  if (!t || !SwigType_isarray(t))
+    return;
+
+  Setattr(n, "transform_array_type:type", Copy(t));
+
+  int ndim = SwigType_array_ndim(t);
+  for (int i = 0; i < ndim; i++) {
+    String *dim = SwigType_array_getdim(t, i);
+    if (!dim || Len(dim) == 0) {
+      SwigType_array_setdim(t, i, "*");
+    }
+  }
+}
+
+/* -------------------------------------------------------------------------
+ * \brief Replace '.a()' with '.a(*)' to transform C unspecified array dimensions to Fortran 'deferred' array dimensions 
+ */
+void restore_array_type(Node *n) {
+  SwigType *t = Getattr(n, "transform_array_type:type");
+  if (!t)
+    return;
+
+  Setattr(n, "type", t);
+  Delattr(n, "transform_array_type:type");
+}
+
+/* -------------------------------------------------------------------------
  * \brief Check a parameter for invalid dimension names.
  */
-int fix_fortran_dims(Node *n, const char *tmap_name, String *typemap) {
+int check_fortran_dims(Node *n, const char *tmap_name, String *typemap) {
   String *key = NewStringf("tmap:%s:checkdim", tmap_name);
   bool is_checkdims = GetFlag(n, key);
   Delete(key);
   if (!is_checkdims)
     return SWIG_OK;
   
-  SwigType* t = Getattr(n, "type");
-  ASSERT_OR_PRINT_NODE(SwigType_isarray(t), n);
+  SwigType *t = Getattr(n, "type");
+  if (!SwigType_isarray(t))
+    return SWIG_OK;
+
   int ndim = SwigType_array_ndim(t);
   for (int i = 0; i < ndim; i++) {
     String *dim = SwigType_array_getdim(t, i);
-    if (dim && Len(dim) > 0 && !is_fortran_intexpr(dim)) {
+    if (dim && Len(dim) > 0 && Strcmp(dim, "*") != 0 &&  !is_fortran_intexpr(dim)) {
       Swig_warning(WARN_LANG_IDENTIFIER, input_file, line_number,
                    "Array dimension expression '%s' is incompatible with Fortran\n",
                    dim);
@@ -133,10 +166,6 @@ int fix_fortran_dims(Node *n, const char *tmap_name, String *typemap) {
     }
     Delete(dim);
   }
-
-  // Replace empty dimensions with assumed-size dimension
-  Replaceall(typemap, "dimension()", "dimension(*)");
-  Replaceall(typemap, ",)", ",*)");
 
   return SWIG_OK;
 }
@@ -1568,7 +1597,13 @@ Wrapper *FORTRAN::imfuncWrapper(Node *n) {
   // >>> FUNCTION PARAMETERS/ARGUMENTS
 
   ParmList *parmlist = Getattr(n, "parms");
+  for (Iterator it = First(parmlist); it.item; it = Next(it)) {
+    transform_array_type(it.item);
+  }
   Swig_typemap_attach_parms(tmtype, parmlist, NULL);
+  for (Iterator it = First(parmlist); it.item; it = Next(it)) {
+    restore_array_type(it.item);
+  }
 
   // Get the list of actual parameters used by the C function
   // (these are pointers to values in parmlist, with some elements possibly
@@ -1591,7 +1626,7 @@ Wrapper *FORTRAN::imfuncWrapper(Node *n) {
 
     // Add dummy argument to wrapper body
     String *imtype = get_typemap(tmtype, "in", p, warning_flag);
-    if (fix_fortran_dims(p, tmtype, imtype) != SWIG_OK) {
+    if (check_fortran_dims(p, tmtype, imtype) != SWIG_OK) {
       DelWrapper(imfunc);
       return NULL;
     }
@@ -1645,8 +1680,15 @@ Wrapper *FORTRAN::proxyfuncWrapper(Node *n) {
 
   // >>> FUNCTION RETURN VALUES
 
+  transform_array_type(n);
   String *return_ftype = attach_typemap("ftype", n, WARN_FORTRAN_TYPEMAP_FTYPE_UNDEF);
+  restore_array_type(n);
   assert(return_ftype);
+
+  if (check_fortran_dims(n, "ftype", return_ftype) != SWIG_OK) {
+    DelWrapper(ffunc);
+    return NULL;
+  }
 
   // Return type for the C call
   String *return_imtype = get_typemap("imtype", n, WARN_NONE);
@@ -1792,9 +1834,15 @@ Wrapper *FORTRAN::proxyfuncWrapper(Node *n) {
 
   // Attach proxy input typemap (proxy arg -> farg1 in fortran function)
   ParmList *parmlist = Getattr(n, "parms");
+  for (Iterator it = First(cparmlist); it.item; it = Next(it)) {
+    transform_array_type(it.item);
+  }
   Swig_typemap_attach_parms("ftype", parmlist, ffunc);
   Swig_typemap_attach_parms("fin", parmlist, ffunc);
   Swig_typemap_attach_parms("fargout", parmlist, ffunc);
+  for (Iterator it = First(cparmlist); it.item; it = Next(it)) {
+    restore_array_type(it.item);
+  }
 
   // Restore parameter names
   for (Iterator it = First(cparmlist); it.item; it = Next(it)) {
@@ -1870,7 +1918,7 @@ Wrapper *FORTRAN::proxyfuncWrapper(Node *n) {
 
     // Add dummy argument to wrapper body
     String *ftype = get_typemap("ftype", "in", p, WARN_FORTRAN_TYPEMAP_FTYPE_UNDEF);
-    if (fix_fortran_dims(p, "ftype", ftype) != SWIG_OK) {
+    if (check_fortran_dims(p, "ftype", ftype) != SWIG_OK) {
       DelWrapper(ffunc);
       return NULL;
     }
@@ -1939,6 +1987,7 @@ Wrapper *FORTRAN::proxyfuncWrapper(Node *n) {
   // Get the typemap for output argument conversion
   Parm *outparm = NewParm(return_cpptype, Getattr(n, "name"), n);
   Setattr(outparm, "lname", "fresult"); // Replaces $1
+  transform_array_type(outparm);
   String *fbody = attach_typemap("fout", outparm, WARN_FORTRAN_TYPEMAP_FOUT_UNDEF);
 
   // Add any needed temporary variables
@@ -2792,7 +2841,7 @@ int FORTRAN::constantWrapper(Node *n) {
   }
 
   // Check for incompatible array dimensions
-  if (fix_fortran_dims(n, "bindc", bindc_typestr) != SWIG_OK) {
+  if (check_fortran_dims(n, "bindc", bindc_typestr) != SWIG_OK) {
     return SWIG_NOWRAP;
   }
 


### PR DESCRIPTION
This changes the behavior of arrays and pointers of fundamental types to be consistent with other SWIG languages. Notably, raw pointers are wrapped as opaque classes, since the same pointer could signify single elements or arrays. Arrays are treated the same.

Fortran-like array interaction can be restored using `<typemaps.i>` and applying the `SWIGTYPE ARRAY` to the desired variables.