### PR TITLE
Fix inconsistencies with null shared pointers

### DIFF
--- a/Examples/test-suite/fortran/fortran_ownership_runme.F90
+++ b/Examples/test-suite/fortran/fortran_ownership_runme.F90
@@ -56,6 +56,11 @@ subroutine test_standard
   ASSERT(.not. btest(b%swigdata%cmemflags, swig_cmem_rvalue_bit))
   ASSERT(foo_counter == 3)
 
+  ! Return null
+  call b%release()
+  b = get_null()
+  ASSERT(.not. c_associated(b%swigdata%cptr))
+
   ! Capture from function
   b = make_foo(6)
   ASSERT(btest(b%swigdata%cmemflags, swig_cmem_own_bit))

--- a/Examples/test-suite/fortran/li_boost_shared_ptr_runme.F90
+++ b/Examples/test-suite/fortran/li_boost_shared_ptr_runme.F90
@@ -8,7 +8,6 @@ program li_boost_shared_ptr_runme
   implicit none
   type(Klass) :: f1, f2
   integer(c_int) :: orig_total_count
-  integer(c_int) :: memory_leak
 
   !call set_debug_shared(.true.)
 
@@ -40,6 +39,17 @@ program li_boost_shared_ptr_runme
   call f1%release() ! Clear the raw pointer (does not deallocate)
   ASSERT(use_count(f1) == 0)
 
+  ! Test null pointers
+  f1 = sp_pointer_null()
+  ASSERT(nullsmartpointerpointertest(f1) == "null pointer")
+  call f1%release()
+  f1 = null_sp_pointer()
+  ASSERT(nullsmartpointerpointertest(f1) == "null pointer")
+  call f1%release()
+  f1 = sp_value_null()
+  ASSERT(nullsmartpointerpointertest(f1) == "null pointer")
+  call f1%release()
+
   ! Copy-construct the underlying object
   f1 = Klass(f2)
   ASSERT(use_count(f1) == 1)
@@ -52,12 +62,7 @@ program li_boost_shared_ptr_runme
 
   call f2%release() ! Further calls to release() are allowable null-ops
 
-  ! Create a temporary shared pointer that's passed into a function
-  ! THIS LEAKS MEMORY!
-  ASSERT(use_count(Klass()) == 1)
-  memory_leak = 1
-
   ! The getTotal_count function is static, so 'f2' doesn't have to be allocated
-  ASSERT(f2%getTotal_count() == orig_total_count + memory_leak)
+  ASSERT(f2%getTotal_count() == orig_total_count)
 end program
 

--- a/Examples/test-suite/fortran_ownership.i
+++ b/Examples/test-suite/fortran_ownership.i
@@ -43,6 +43,7 @@ Foo& reference(Foo& other) { return other; }
 const Foo& const_reference(const Foo& other) { return other; }
 Foo make_foo(int val) { return Foo(val); }
 Foo make_foo_subroutine(int val) { return Foo(val); }
+Foo* get_null() { return NULL; }
 
 int get_value(const Foo& other) { return other.val; }
 int get_value_copy(Foo other) { return other.val; }

--- a/Examples/test-suite/li_boost_shared_ptr.i
+++ b/Examples/test-suite/li_boost_shared_ptr.i
@@ -242,6 +242,10 @@ std::string nullsmartpointerpointertest(SwigBoost::shared_ptr<Klass>* k) {
   else
     return "also not null";
 }
+
+SwigBoost::shared_ptr<Klass>* sp_pointer_null() { return NULL; }
+SwigBoost::shared_ptr<Klass>* null_sp_pointer() { static SwigBoost::shared_ptr<Klass> static_sp; return &static_sp; }
+SwigBoost::shared_ptr<Klass> sp_value_null() { return SwigBoost::shared_ptr<Klass>(); }
 // $owner
 Klass *pointerownertest() {
   return new Klass("pointerownertest");

--- a/Lib/fortran/boost_shared_ptr.i
+++ b/Lib/fortran/boost_shared_ptr.i
@@ -101,10 +101,12 @@
 /* -------------------------------------------------------------------------
  * Original class by reference. Add null checks.
  * ------------------------------------------------------------------------- */
-%typemap(in, noblock=1, fragment="SWIG_check_sp_nonnull") CONST TYPE& {
+%typemap(in, noblock=1, fragment="SWIG_check_sp_nonnull") CONST TYPE & {
   SWIG_check_sp_nonnull($input->cptr, "$1_ltype", "$fclassname", "$decl", return $null)
   $1 = (TYPE*)static_cast<SWIGSP__*>($input->cptr)->get();
 }
+
+%typemap(in) CONST TYPE &ASSIGNMENT_OTHER = SWIGTYPE *ASSIGNMENT_SELF;
 
 // Output value is never null. Because we're allocating a shared pointer, we set the memory ownership to MOVE so that the *SP*
 // will be properly deallocated. But we also must use a null deleter so that when the SP is deleted the corresponding memory


### PR DESCRIPTION
A function could previously return a shared pointer by value
that was unassigned, leading to possible null pointer dereferences
when called later. @aprokop This should fix that crash you had in ForTrilinos. Validity can be checked with `c_associated(wrapper%swigdata%cptr)`.