### PR TITLE
Fix 'delete' operation

### DIFF
--- a/Examples/fortran/check.list
+++ b/Examples/fortran/check.list
@@ -8,6 +8,7 @@ except
 funcptr
 inheritance
 simple
+spdemo
 static_members
 std_string
 templated

--- a/Examples/fortran/class/runme.f90
+++ b/Examples/fortran/class/runme.f90
@@ -11,6 +11,7 @@ subroutine run()
   type(Circle)          :: c
   type(Square), target  :: s ! 'target' allows it to be pointed to
   class(Shape), pointer :: sh
+  integer(C_INT) :: n_shapes
 
   ! ----- Object creation -----
     
@@ -60,7 +61,13 @@ subroutine run()
   call c%release()
   call s%release()
 
-  write(*,*)c%get_nshapes(), "shapes remain"
+  n_shapes = c%get_nshapes() 
+  write(*,*) n_shapes, "shapes remain"
+  if (n_shapes /= 0) then
+    write(*,*) "Shapes were not freed properly!"
+    stop 1
+  endif
+
   write(*,*) "Goodbye"
 end subroutine
 

--- a/Examples/fortran/spdemo/example.cxx
+++ b/Examples/fortran/spdemo/example.cxx
@@ -38,6 +38,11 @@ std::shared_ptr<Foo> Foo::clone_sp() const {
   return std::make_shared<Foo>(*this);
 }
 
+int use_count(const std::shared_ptr<Foo> *f) {
+  if (!f) return 0;
+  return f->use_count();
+}
+
 void print_sp(std::shared_ptr<Foo> f) {
   cout << "Shared pointer at " << &f << " with reference count " << f.use_count() << ": ";
   print_crsp(f);

--- a/Examples/fortran/spdemo/example.cxx
+++ b/Examples/fortran/spdemo/example.cxx
@@ -34,31 +34,31 @@ Foo Foo::clone() const {
   return *this;
 }
 
-std::shared_ptr<Foo> Foo::clone_sp() const {
-  return std::make_shared<Foo>(*this);
+shared_ptr<Foo> Foo::clone_sp() const {
+  return shared_ptr<Foo>(new Foo(*this));
 }
 
-int use_count(const std::shared_ptr<Foo> *f) {
+int use_count(const shared_ptr<Foo> *f) {
   if (!f) return 0;
   return f->use_count();
 }
 
-void print_sp(std::shared_ptr<Foo> f) {
+void print_sp(shared_ptr<Foo> f) {
   cout << "Shared pointer at " << &f << " with reference count " << f.use_count() << ": ";
   print_crsp(f);
 }
 
-void print_crsp(const std::shared_ptr<Foo> &f) {
+void print_crsp(const shared_ptr<Foo> &f) {
   cout << "Shared pointer at " << &f << " with reference count " << f.use_count() << ": ";
   print_crspc(f);
 }
 
-void print_spc(std::shared_ptr<const Foo> f) {
+void print_spc(shared_ptr<const Foo> f) {
   cout << "Shared pointer at " << &f << " with reference count " << f.use_count() << ": ";
   print_crspc(f);
 }
 
-void print_crspc(const std::shared_ptr<const Foo> &f) {
+void print_crspc(const shared_ptr<const Foo> &f) {
   if (!f)
     throw std::logic_error("got null sp");
 

--- a/Examples/fortran/spdemo/example.h
+++ b/Examples/fortran/spdemo/example.h
@@ -29,10 +29,7 @@ public:
   const Foo *ptr() const { return this; }
 };
 
-int use_count(const std::shared_ptr<Foo> *f) {
-  if (!f) return 0;
-  return f->use_count();
-}
+int use_count(const std::shared_ptr<Foo> *f);
 void print_crsp(const std::shared_ptr<Foo> &f);
 void print_sp(std::shared_ptr<Foo> f);
 void print_spc(std::shared_ptr<const Foo> f);

--- a/Examples/fortran/spdemo/example.h
+++ b/Examples/fortran/spdemo/example.h
@@ -1,6 +1,8 @@
 /* File : example.h */
 
-#include <memory>
+
+#include "boost/shared_ptr.hpp"
+using boost::shared_ptr;
 
 class Foo {
 public:
@@ -19,7 +21,7 @@ public:
   // Return a copy by value
   Foo clone() const;
   // Return an SP copy
-  std::shared_ptr<Foo> clone_sp() const;
+  shared_ptr<Foo> clone_sp() const;
 
   // Return references to ourself
   Foo &mutable_ref() { return *this; }
@@ -29,10 +31,10 @@ public:
   const Foo *ptr() const { return this; }
 };
 
-int use_count(const std::shared_ptr<Foo> *f);
-void print_crsp(const std::shared_ptr<Foo> &f);
-void print_sp(std::shared_ptr<Foo> f);
-void print_spc(std::shared_ptr<const Foo> f);
-void print_crspc(const std::shared_ptr<const Foo> &f);
+int use_count(const shared_ptr<Foo> *f);
+void print_crsp(const shared_ptr<Foo> &f);
+void print_sp(shared_ptr<Foo> f);
+void print_spc(shared_ptr<const Foo> f);
+void print_crspc(const shared_ptr<const Foo> &f);
 void print_cr(const Foo &f);
 

--- a/Examples/fortran/spdemo/example.i
+++ b/Examples/fortran/spdemo/example.i
@@ -6,7 +6,7 @@
 #include "example.h"
 %}
 
-%include <std_shared_ptr.i>
+%include <boost_shared_ptr.i>
 %shared_ptr(Foo);
 %include "example.h"
 

--- a/Examples/fortran/spdemo/runme.f90
+++ b/Examples/fortran/spdemo/runme.f90
@@ -5,7 +5,7 @@ program main
   use ISO_FORTRAN_ENV
   implicit none
 
-  !call test_class()
+  call test_class()
   call test_spcopy()
 
 contains

--- a/Lib/fortran/classes.swg
+++ b/Lib/fortran/classes.swg
@@ -352,6 +352,7 @@ SWIGINTERN void SWIG_assign(SwigClassWrapper* self, SwigClassWrapper other) {
 %typemap(ftype, in="class($fclassname), intent(inout)", nofortransubroutine=1) SWIGTYPE *ASSIGNMENT_SELF
   "type($fclassname)"
 
+// Assignment operates directly on $input, not $1
 %typemap(in) SWIGTYPE *ASSIGNMENT_SELF "(void)sizeof($1);";
 %typemap(fargout, noblock=1) SWIGTYPE *ASSIGNMENT_SELF {
   $input%swigdata = $1
@@ -363,4 +364,5 @@ SWIGINTERN void SWIG_assign(SwigClassWrapper* self, SwigClassWrapper other) {
 %typemap(in) SWIGTYPE &ASSIGNMENT_OTHER = SWIGTYPE *ASSIGNMENT_SELF;
 
 %apply SWIGTYPE *ASSIGNMENT_SELF { SWIGTYPE *DESTRUCTOR_SELF };
+%typemap(in) SWIGTYPE *DESTRUCTOR_SELF = SWIGTYPE *;
 

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -2457,6 +2457,11 @@ int FORTRAN::destructorHandler(Node *n) {
   Setattr(n, "fortran:name", "release");
   SetFlag(n, "fortran:ismember");
 
+  // Throwing in a destructor calls `std::terminate`, so don't bother adding wrapper code
+  if (!GetFlag(n, "feature:allowexcept")) {
+    UnsetFlag(n, "feature:except");
+  }
+
   // Add swigf_ to constructor name
   String *fname = proxy_name_construct(this->getNSpace(), "release", Getattr(n, "sym:name"));
   Setattr(n, "fortran:fname", fname);


### PR DESCRIPTION
I think the changes in #123 caused `delete` on regular objects to become a null-op. This adds a test and fixes it.