### PR TITLE
Fix argout code generation

### DIFF
--- a/Examples/test-suite/fortran/ignore_parameter_runme.F90
+++ b/Examples/test-suite/fortran/ignore_parameter_runme.F90
@@ -1,0 +1,16 @@
+! File : ignore_parameter_runme.F90
+
+#include "fassert.h"
+
+program ignore_parameter_runme
+  use ignore_parameter
+  use ISO_C_BINDING
+  implicit none
+  ASSERT(jaguar(200, 0.0d0) == "hello")
+
+  ASSERT(get_called_argout() == 0)
+  ASSERT(lotus("fast", 0.0d0) == 101)
+  ASSERT(get_called_argout() == 1)
+end program
+
+

--- a/Examples/test-suite/ignore_parameter.i
+++ b/Examples/test-suite/ignore_parameter.i
@@ -3,12 +3,19 @@
 %module ignore_parameter
 
 %typemap(in,numinputs=0) char* a "static const char* hi = \"hello\"; $1 = const_cast<char *>(hi);";
-%typemap(in,numinputs=0) int bb "$1 = 101;";
+%typemap(in,numinputs=0) int bb "$1 = 101; called_argout = 0;";
 %typemap(in,numinputs=0) double ccc "$1 = 8.8;";
 
 %typemap(freearg) char* a ""; // ensure freearg is not generated (needed for Java at least)
 
+%typemap(freearg) char* a ""; // ensure freearg is not generated (needed for Java at least)
+
+%typemap(argout, match="in") int bb "called_argout = 1;"
+
 %inline %{
+// constant for detecting correct "argout" call
+int called_argout = 0;
+
 // global function tests
 char* jaguar(char* a, int b, double c) { return a; }
 int lotus(char* aa, int bb, double cc) { return bb; }

--- a/Examples/test-suite/ignore_parameter.i
+++ b/Examples/test-suite/ignore_parameter.i
@@ -10,7 +10,7 @@
 
 %typemap(freearg) char* a ""; // ensure freearg is not generated (needed for Java at least)
 
-%typemap(argout, match="in") int bb "called_argout = 1;"
+%typemap(argout) int bb "called_argout = 1;"
 
 %inline %{
 // constant for detecting correct "argout" call


### PR DESCRIPTION
When the input parameter was ignored with `numinputs=0`, the argout code wouldn't be added to the wrapper.