### PR TITLE
Remove `fenumname` and replace `fclassname` with `fortranclassname`

### DIFF
--- a/Doc/Manual/src/Fortran.md
+++ b/Doc/Manual/src/Fortran.md
@@ -1689,15 +1689,16 @@ Fortran compiler), `release` should be called on every proxy class instance.
 SWIG's default Fortran type (the `ftype` typemap) for generic types such as
 classes (`SWIGTYPE`) is:
 ```swig
-%typemap(ftype) SWIGTYPE "type($fclassname)"
+%typemap(ftype) SWIGTYPE "type($fortranclassname)"
 ```
-The special symbol `$fclassname` is replaced by the symbolic name of the class
-that matches the typemap. For example, if `std::vector<double>` is
+The special symbol `$fortranclassname` is replaced by the symbolic name (i.e. the Fortran
+identifier in the proxy code) of the class that matches the typemap.
+For example, if `std::vector<double>` is
 instantiated:
 ```swig
 %template(Vec_Dbl) std::vector<double>;
 ```
-then `Vec_Dbl`, the name of the derived type, will replace `$fclassname`.
+then `Vec_Dbl`, the name of the derived type, will replace `$fortranclassname`.
 
 If a class has *not* been wrapped but is encountered (e.g. in a function
 argument or return value), a warning will be emitted: no Fortran

--- a/Lib/fortran/bindc.swg
+++ b/Lib/fortran/bindc.swg
@@ -3,8 +3,8 @@
  * ------------------------------------------------------------------------- */
 
 // Declare a generic `FORTRAN_STRUCT_TYPE` as a native type.
-// Rather than being an intrinsic type `integer(C_INT)` it's a derived type `type($fclassname)`
-%fortran_intrinsic(FORTRAN_STRUCT_TYPE, type($fclassname))
+// Rather than being an intrinsic type `integer(C_INT)` it's a derived type `type($fortranclassname)`
+%fortran_intrinsic(FORTRAN_STRUCT_TYPE, type($fortranclassname))
 // Avoid 'C99 forbids casting nonscalar type 'XY' to the same type'
 %typemap(in) FORTRAN_STRUCT_TYPE "$1 = *$input;"
 %typemap(out) FORTRAN_STRUCT_TYPE "$result = $1;"

--- a/Lib/fortran/boost_shared_ptr.i
+++ b/Lib/fortran/boost_shared_ptr.i
@@ -62,7 +62,7 @@
  * SP-owned copy of the obtained value.
  * ------------------------------------------------------------------------- */
 %typemap(in, noblock=1, fragment="SWIG_check_sp_nonnull") CONST TYPE ($&1_type argp = 0) {
-  SWIG_check_sp_nonnull($input->cptr, "$1_ltype", "$fclassname", "$decl", return $null)
+  SWIG_check_sp_nonnull($input->cptr, "$1_ltype", "$fortranclassname", "$decl", return $null)
   argp = static_cast<SWIGSP__*>($input->cptr)->get();
   $1 = *argp;
 }
@@ -102,7 +102,7 @@
  * Original class by reference. Add null checks.
  * ------------------------------------------------------------------------- */
 %typemap(in, noblock=1, fragment="SWIG_check_sp_nonnull") CONST TYPE & {
-  SWIG_check_sp_nonnull($input->cptr, "$1_ltype", "$fclassname", "$decl", return $null)
+  SWIG_check_sp_nonnull($input->cptr, "$1_ltype", "$fortranclassname", "$decl", return $null)
   $1 = (TYPE*)static_cast<SWIGSP__*>($input->cptr)->get();
 }
 

--- a/Lib/fortran/classes.swg
+++ b/Lib/fortran/classes.swg
@@ -323,11 +323,11 @@ SWIGINTERN void SWIG_assign(SwigClassWrapper* self, SwigClassWrapper other) {
 %typemap(imtype, fragment="SwigClassWrapper_f")
     SWIGTYPE
   "type(SwigClassWrapper)"
-%typemap(ftype, in="type($&fclassname), intent(in)", nofortransubroutine=1) SWIGTYPE
-  "type($&fclassname)"
+%typemap(ftype, in="type($&fortranclassname), intent(in)", nofortransubroutine=1) SWIGTYPE
+  "type($&fortranclassname)"
 
 %typemap(in, noblock=1, fragment="SWIG_check_nonnull") SWIGTYPE {
-  SWIG_check_nonnull(*$input, "$1_ltype", "$&fclassname", "$decl", return $null);
+  SWIG_check_nonnull(*$input, "$1_ltype", "$&fortranclassname", "$decl", return $null);
   $1 = *(($&1_ltype)($input->cptr));
 }
 
@@ -352,8 +352,8 @@ SWIGINTERN void SWIG_assign(SwigClassWrapper* self, SwigClassWrapper other) {
 // Raw pointers act mostly like value types, but they don't have to accept the exact type (polymorphic input, non-polymorphic output). Intent is 'in' because
 // we're not modifying the pointer or memory status.
 %apply SWIGTYPE { SWIGTYPE* };
-%typemap(ftype, in="class($fclassname), intent(in)", nofortransubroutine=1) SWIGTYPE*
-  "type($fclassname)"
+%typemap(ftype, in="class($fortranclassname), intent(in)", nofortransubroutine=1) SWIGTYPE*
+  "type($fortranclassname)"
 %typemap(in, noblock=1) SWIGTYPE* {
   $1 = ($1_ltype)$input->cptr;
 }
@@ -373,7 +373,7 @@ SWIGINTERN void SWIG_assign(SwigClassWrapper* self, SwigClassWrapper other) {
 // Check for non-null reference inputs
 %apply SWIGTYPE* { SWIGTYPE& };
 %typemap(in, noblock=1, fragment="SWIG_check_nonnull") SWIGTYPE& {
-  SWIG_check_nonnull(*$input, "$1_type", "$fclassname", "$decl", return $null);
+  SWIG_check_nonnull(*$input, "$1_type", "$fortranclassname", "$decl", return $null);
   $1 = ($1_ltype)$input->cptr;
 }
 
@@ -397,15 +397,15 @@ SWIGINTERN void SWIG_assign(SwigClassWrapper* self, SwigClassWrapper other) {
 
 // Check for non-null class input "self"
 %typemap(in, noblock=1, fragment="SWIG_check_nonnull") SWIGTYPE *self {
-  SWIG_check_nonnull(*$input, "$1_type", "$*fclassname", "$decl", return $null);
+  SWIG_check_nonnull(*$input, "$1_type", "$*fortranclassname", "$decl", return $null);
   $1 = ($1_ltype)$input->cptr;
 }
 
 // On assignment, copy pointer to input wrapper class
 %typemap(imtype, in="type(SwigClassWrapper), intent(inout)", fragment="SwigClassWrapper_f") SWIGTYPE *ASSIGNMENT_SELF
   "type(SwigClassWrapper)"
-%typemap(ftype, in="class($fclassname), intent(inout)", nofortransubroutine=1) SWIGTYPE *ASSIGNMENT_SELF
-  "type($fclassname)"
+%typemap(ftype, in="class($fortranclassname), intent(inout)", nofortransubroutine=1) SWIGTYPE *ASSIGNMENT_SELF
+  "type($fortranclassname)"
 
 // Assignment operates directly on $input, not $1
 %typemap(in) SWIGTYPE *ASSIGNMENT_SELF "(void)sizeof($1);";
@@ -414,8 +414,8 @@ SWIGINTERN void SWIG_assign(SwigClassWrapper* self, SwigClassWrapper other) {
 }
 
 // Prevent ambiguous overloads by requiring the RHS to be the exact type
-%typemap(ftype, in="type($fclassname), intent(in)", nofortransubroutine=1) SWIGTYPE &ASSIGNMENT_OTHER
-  "type($fclassname)"
+%typemap(ftype, in="type($fortranclassname), intent(in)", nofortransubroutine=1) SWIGTYPE &ASSIGNMENT_OTHER
+  "type($fortranclassname)"
 %typemap(in) SWIGTYPE &ASSIGNMENT_OTHER = SWIGTYPE *ASSIGNMENT_SELF;
 
 %apply SWIGTYPE *ASSIGNMENT_SELF { SWIGTYPE *DESTRUCTOR_SELF };

--- a/Lib/fortran/enums.swg
+++ b/Lib/fortran/enums.swg
@@ -11,8 +11,8 @@
 // integer pointers)
 %fortran_unsigned(int, enum SWIGTYPE)
 
-%typemap(ftype, in="integer($fenumname), intent(in)") enum SWIGTYPE
-  "integer($fenumname)"
+%typemap(ftype, in="integer($fclassname), intent(in)") enum SWIGTYPE
+  "integer($fclassname)"
 %typemap(out, noblock=1) enum SWIGTYPE {
   $result = (int)($1);
 }
@@ -20,8 +20,8 @@
   $result = (int)(*$1);
 }
 
-%typemap(ftype, in="integer($*fenumname), intent(in)") const enum SWIGTYPE&
-  "integer($*fenumname)"
+%typemap(ftype, in="integer($*fclassname), intent(in)") const enum SWIGTYPE&
+  "integer($*fclassname)"
 %typemap(imtype) const enum SWIGTYPE& = enum SWIGTYPE;
 %typemap(fin)    const enum SWIGTYPE& = enum SWIGTYPE;
 %typemap(fout)   const enum SWIGTYPE& = enum SWIGTYPE;

--- a/Lib/fortran/enums.swg
+++ b/Lib/fortran/enums.swg
@@ -11,8 +11,8 @@
 // integer pointers)
 %fortran_unsigned(int, enum SWIGTYPE)
 
-%typemap(ftype, in="integer($fclassname), intent(in)") enum SWIGTYPE
-  "integer($fclassname)"
+%typemap(ftype, in="integer($fortranclassname), intent(in)") enum SWIGTYPE
+  "integer($fortranclassname)"
 %typemap(out, noblock=1) enum SWIGTYPE {
   $result = (int)($1);
 }
@@ -20,8 +20,8 @@
   $result = (int)(*$1);
 }
 
-%typemap(ftype, in="integer($*fclassname), intent(in)") const enum SWIGTYPE&
-  "integer($*fclassname)"
+%typemap(ftype, in="integer($*fortranclassname), intent(in)") const enum SWIGTYPE&
+  "integer($*fortranclassname)"
 %typemap(imtype) const enum SWIGTYPE& = enum SWIGTYPE;
 %typemap(fin)    const enum SWIGTYPE& = enum SWIGTYPE;
 %typemap(fout)   const enum SWIGTYPE& = enum SWIGTYPE;


### PR DESCRIPTION
This makes the fortran typemaps even closer to existing statically typed languages, and eliminating fenumname paves the way for strongly typed function pointers (#116 )