### PR TITLE
Fix fortran typemaps for arrays on PGI

### DIFF
--- a/Lib/fortran/fortranstrings.swg
+++ b/Lib/fortran/fortranstrings.swg
@@ -27,7 +27,7 @@ subroutine %fortrantm(fin, char*)(finp, iminp, temp)
   i = len(finp) + 1
   temp(i) = C_NULL_CHAR ! C finp compatibility
   iminp%data = c_loc(temp)
-  iminp%size = len(finp)
+  iminp%size = len(finp, kind=C_SIZE_T)
 end subroutine
 }
 

--- a/Lib/fortran/fundamental.swg
+++ b/Lib/fortran/fundamental.swg
@@ -168,16 +168,17 @@ SWIGINTERN SwigArrayWrapper SwigArrayWrapper_uninitialized() {
   use, intrinsic :: ISO_C_BINDING
   FTYPE, dimension(:), intent(in), target :: finp
   type(SwigArrayWrapper), intent(out) :: iminp
+  integer(C_SIZE_T) :: sz
   FTYPE, pointer :: imtemp
 
-  if (size(finp) > 0) then
+  sz = size(finp, kind=C_SIZE_T)
+  if (sz > 0_c_size_t) then
     imtemp => finp(1)
     iminp%data = c_loc(imtemp)
-    iminp%size = size(finp)
   else
     iminp%data = c_null_ptr
-    iminp%size = 0
   end if
+  iminp%size = sz
 end subroutine}
 
   // Fragment for converting array wrapper to array

--- a/Lib/fortran/openacc.i
+++ b/Lib/fortran/openacc.i
@@ -32,7 +32,7 @@
 
   %typemap(fin, noblock=1, fragment="f_use_openacc") CPPTYPE {
     $1%data = acc_deviceptr($input)
-    $1%size = size($input)
+    $1%size = size($input, kind=c_int)
   }
 
   %typemap(ftype, noblock=1) CPPTYPE {


### PR DESCRIPTION
PGI 15.7 fails to compile the fundamental type transformation subroutines with
error "PGF90-S-0095-Expression has wrong data type". This change explicitly
forces the `size` intrinsic to return the same integer type as the right-hand
side of the comparison.