### PR TITLE
Automated generation of *abstract* bind(C) interface

### DIFF
--- a/Doc/Manual/src/Fortran.md
+++ b/Doc/Manual/src/Fortran.md
@@ -1857,6 +1857,7 @@ Fortran standard's specification and naming of the components of a module.
 <tr><td><code>fbegin     </code></td><td>Code before the `module` statement </td></tr>
 <tr><td><code>fuse       </code></td><td>"use" statements                   </td></tr>
 <tr><td><code>fdecl      </code></td><td>Module declarations                </td></tr>
+<tr><td><code>fabstract</code></td><td>Abstract interfaces for callbacks</td></tr>
 <tr><td><code>finterfaces</code></td><td>Procedure interfaces for C code    </td></tr>
 <tr><td><code>fsubprograms</code></td><td>Fortran module subprograms        </td></tr>
 </tbody>

--- a/Examples/fortran/funcptr/example.c
+++ b/Examples/fortran/funcptr/example.c
@@ -1,19 +1,19 @@
 /* File : example.c */
 
-int do_op(int a, int b, int (*op)(int,int)) {
-  return (*op)(a,b);
+int do_op(int a, int b, int (*op)(int, int)) {
+  return (*op)(a, b);
 }
 
 int add(int a, int b) {
-  return a+b;
+  return a + b;
 }
 
 int sub(int a, int b) {
-  return a-b;
+  return a - b;
 }
 
 int mul(int a, int b) {
-  return a*b;
+  return a * b;
 }
 
-int (*funcvar)(int,int) = add;
+int (*funcvar)(int, int) = add;

--- a/Examples/fortran/funcptr/example.h
+++ b/Examples/fortran/funcptr/example.h
@@ -1,9 +1,11 @@
 /* file: example.h */
 
-extern int do_op(int,int, int (*op)(int,int));
-extern int add(int,int);
-extern int sub(int,int);
-extern int mul(int,int);
+typedef int (*binary_func)(int, int);
 
-extern int (*funcvar)(int,int);
+extern int do_op(int, int, binary_func);
+extern int add(int, int);
+extern int sub(int, int);
+extern int mul(int, int);
+
+extern int (*funcvar)(int, int);
 

--- a/Examples/fortran/funcptr/example.i
+++ b/Examples/fortran/funcptr/example.i
@@ -4,8 +4,14 @@
 #include "example.h"
 %}
 
+%fortrancallback("%s") binary_op;
+int binary_op(int a, int b);
+
+/* Function pointer: f(int, int) ->  int */
+typedef int (*binary_func)(int, int);
+
 /* Wrap a function taking a pointer to a function */
-extern int  do_op(int a, int b, int (*op)(int, int));
+extern int do_op(int a, int b, binary_func op);
 
 /* Now install a bunch of "ops" as constants */
 %constant int (*ADD)(int,int) = add;

--- a/Examples/fortran/funcptr/runme.f90
+++ b/Examples/fortran/funcptr/runme.f90
@@ -4,16 +4,6 @@ module fortran_ops
   implicit none
   public
     
-  abstract interface
-    ! Interface corresponding to the C typedef "BinaryOp"
-    function binary_op(aa, bb) bind(C)  result(cc)
-      use, intrinsic :: ISO_C_BINDING
-      integer(C_INT), intent(in), value :: aa
-      integer(C_INT), intent(in), value :: bb
-      integer(C_INT) :: cc
-    end function
-  end interface
-  
 contains
   ! Fortran function that we can export so that
   ! it's available to C code
@@ -39,19 +29,16 @@ program fortran_funptr_runme
   integer, parameter :: STDOUT = OUTPUT_UNIT
   integer(C_INT) :: a = 4
   integer(C_INT) :: b = 3
-  type(C_FUNPTR) :: temp_funptr
-  procedure(binary_op), pointer :: my_ffunc => null()
+  procedure(binary_op), pointer :: fptr => null()
 
-  write(STDOUT,*) "SWIG-wrapped C function pointer:", do_op(a,b,add)
-  write(STDOUT,*) "SWIG-wrapped C function pointer:", do_op(a,b,sub)
-  write(STDOUT,*) "SWIG-wrapped C function pointer:", do_op(a,b,mul)
+  call c_f_procpointer(add, fptr)
+  write(STDOUT,*) "SWIG-wrapped C function pointer:", do_op(a, b, fptr)
+  call c_f_procpointer(sub, fptr)                                 
+  write(STDOUT,*) "SWIG-wrapped C function pointer:", do_op(a, b, fptr)
+  call c_f_procpointer(mul, fptr)                                 
+  write(STDOUT,*) "SWIG-wrapped C function pointer:", do_op(a, b, fptr)
 
   ! Convert Fortran function to C function pointer
-  temp_funptr = c_funloc(fortran_mul)
-  write(STDOUT,*) "C call to Fortran function:", do_op(a,b,temp_funptr)
-
-  ! Convert C function pointer to a Fortran function pointer
-  call c_f_procpointer(add, my_ffunc)
-  write(STDOUT,*) "Fortran direct call to C function:", my_ffunc(a,b)
+  write(STDOUT,*) "C call to Fortran function:", do_op(a, b, fortran_mul)
 
 end program

--- a/Examples/test-suite/fortran/Makefile.in
+++ b/Examples/test-suite/fortran/Makefile.in
@@ -22,6 +22,7 @@ top_builddir = @top_builddir@
 
 CPP_TEST_CASES = \
 	fortran_bindc \
+	fortran_callback \
 	fortran_naming \
 	fortran_onlywrapped \
 	fortran_openacc \
@@ -31,6 +32,7 @@ CPP_TEST_CASES = \
 C_TEST_CASES = \
 	fortran_array_typemap \
 	fortran_bindc_c \
+	fortran_callback_c \
 	fortran_global_const \
 
 FAILING_CPP_TESTS += \

--- a/Examples/test-suite/fortran/fortran_callback_runme.F90
+++ b/Examples/test-suite/fortran/fortran_callback_runme.F90
@@ -1,0 +1,75 @@
+! File : fortran_callback_runme.F90
+
+#include "fassert.h"
+
+module fortran_callback_mod
+  use, intrinsic :: ISO_C_BINDING
+  use ISO_FORTRAN_ENV
+  implicit none
+  integer, parameter :: STDOUT = OUTPUT_UNIT
+  integer(C_INT), save, public :: module_int
+contains
+
+function myexp(left, right) bind(C) &
+    result(fresult)
+  use, intrinsic :: ISO_C_BINDING
+  integer(C_INT), intent(in), value :: left
+  integer(C_INT), intent(in), value :: right
+  integer(C_INT) :: fresult
+
+  fresult = left ** right
+end function
+  
+function mywrite() bind(C) &
+    result(fresult)
+  use, intrinsic :: ISO_C_BINDING
+  integer(C_INT) :: fresult
+  ! write(STDOUT,*) "Hi there"
+  fresult = 256_c_int
+end function
+
+subroutine store_an_int(i) bind(C)
+  use, intrinsic :: ISO_C_BINDING
+  integer(C_INT), value, intent(in) :: i
+  ! write(STDOUT,*) "Got an integer: ", i
+  module_int = i
+end subroutine
+  
+end module
+
+program fortran_callback_runme
+  call test_callback
+contains
+
+subroutine test_callback
+  use fortran_callback
+  use fortran_callback_mod
+  integer(C_INT) :: i
+  procedure(call_binary_cb), pointer :: unused => NULL()
+  procedure(binary_op), pointer :: bin_op_ptr => NULL()
+
+  ! Use callbacks with Fortran module pointers
+  bin_op_ptr => myexp
+  i = call_binary(myexp, 2, 3)
+  ASSERT(i == 8)
+  i = call_things(mywrite)
+  ASSERT(i == 256)
+  call also_call_things(store_an_int, 999)
+  ASSERT(module_int == 999)
+
+  ! Get a C callback
+  bin_op_ptr => get_a_callback("mul")
+  ASSERT(associated(bin_op_ptr))
+  ASSERT(bin_op_ptr(2, 5) == 10)
+
+  bin_op_ptr => get_a_callback("add")
+  ASSERT(associated(bin_op_ptr))
+  ASSERT(bin_op_ptr(2, 5) == 7)
+
+  bin_op_ptr => get_a_callback("nopenope")
+  ASSERT(.not. associated(bin_op_ptr))
+
+end subroutine
+end program
+
+

--- a/Examples/test-suite/fortran/funcptr_runme.F90
+++ b/Examples/test-suite/fortran/funcptr_runme.F90
@@ -2,20 +2,39 @@
 
 #include "fassert.h"
 
+module funcptr_mod
+  use, intrinsic :: ISO_C_BINDING
+  implicit none
+contains
+
+function myexp(left, right) bind(C) &
+    result(fresult)
+  use, intrinsic :: ISO_C_BINDING
+  integer(C_INT), intent(in), value :: left
+  integer(C_INT), intent(in), value :: right
+  integer(C_INT) :: fresult
+
+  fresult = left ** right
+end function
+  
+end module
+
 program funcptr_runme
   use funcptr
+  use funcptr_mod
   use ISO_C_BINDING
   implicit none
-  type(C_FUNPTR) :: fp
+  procedure(SWIGTYPE_f_int_int__int), pointer :: fp
 
-  ! Add
-  call set_handle(0, fp)
+  ! Get the C++ function handle, which starts out as 'add'
+  fp => get_funcvar()
+  ASSERT(fp(2, 3) == 5)
   ASSERT(do_op(2, 3, fp) == 5)
 
-  ! Subtract
-  call set_handle(1, fp)
-  call set_funcvar(fp)
-  ASSERT(do_op(2, 3, get_funcvar()) == -1)
+  ! Set the function handle
+  call set_funcvar(myexp)
+  ! Get it back, then call it from C++
+  ASSERT(do_op(2, 3, get_funcvar()) == 8)
 
 end program
 

--- a/Examples/test-suite/fortran_callback.i
+++ b/Examples/test-suite/fortran_callback.i
@@ -1,0 +1,66 @@
+%module fortran_callback
+
+#ifndef __cplusplus
+// Directly bind all functions: don't create proxy wrappers
+%fortranbindc;
+#endif
+
+// Declare callback signature
+%fortrancallback("%s");
+#ifdef __cplusplus
+extern "C" {
+#endif
+int binary_op(int left, int right);
+void stupid_op(int left, int right);
+void stupider_op();
+#ifdef __cplusplus
+} // end extern
+#endif
+%nofortrancallback;
+
+// Create callbacks and define functions
+%callback("%s_cb");
+
+%inline %{
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int add(int left, int right) { return left + right; }
+int mul(int left, int right) { return left - right; }
+
+#ifdef __cplusplus
+} // end extern
+#endif
+%}
+
+%nocallback;
+
+// Declare callback signature *and* create function with wrapper
+%fortrancallback("%s_cb") call_binary;
+
+%inline %{
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int also_an_int;
+
+typedef int (*binary_op_cb)(int, int);
+int call_binary(binary_op_cb fptr, int left, also_an_int right)
+{ return (*fptr)(left, right); }
+
+#ifdef __cplusplus
+} // end extern
+#endif
+
+typedef int (*noarg_cb)(void);
+int call_things(noarg_cb fptr)
+{ return (*fptr)(); }
+
+typedef void (*one_int_cb)(int);
+void also_call_things(one_int_cb fptr, int val)
+{ return (*fptr)(val); }
+
+%}
+

--- a/Examples/test-suite/fortran_callback.i
+++ b/Examples/test-suite/fortran_callback.i
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 int add(int left, int right) { return left + right; }
-int mul(int left, int right) { return left - right; }
+int mul(int left, int right) { return left * right; }
 
 #ifdef __cplusplus
 } // end extern
@@ -38,6 +38,11 @@ int mul(int left, int right) { return left - right; }
 
 // Declare callback signature *and* create function with wrapper
 %fortrancallback("%s_cb") call_binary;
+
+%{
+#include <string.h>
+#include <stdio.h>
+%}
 
 %inline %{
 #ifdef __cplusplus
@@ -61,6 +66,16 @@ int call_things(noarg_cb fptr)
 typedef void (*one_int_cb)(int);
 void also_call_things(one_int_cb fptr, int val)
 { return (*fptr)(val); }
+
+binary_op_cb get_a_callback(const char* name) {
+  if (strcmp(name, "add") == 0) {
+    return &add;
+  } if (strcmp(name, "mul") == 0) {
+    return &mul;
+  }
+  printf("Invalid callback name '%s'\n", name);
+  return NULL;
+}
 
 %}
 

--- a/Examples/test-suite/fortran_callback_c.i
+++ b/Examples/test-suite/fortran_callback_c.i
@@ -1,0 +1,4 @@
+%module fortran_callback_c
+
+%include "fortran_callback.i"
+

--- a/Examples/test-suite/funcptr.i
+++ b/Examples/test-suite/funcptr.i
@@ -3,23 +3,13 @@
 /*
  Complicated one that should defeat just reading , to find
  the number of arguments expected in the function pointer.
-extern void do(int (*op)(int (*i)(double, double), int j));
+extern void do(int (*op)(int (*i)(double, double), int j)); 
 */
-%{
-#include <stdlib.h>
-%}
 
 %inline %{
 typedef double (*DistFun)(double* data, int r, int c, int i, int j, void *xdata);
 
 void distance(double *data, int *dim, DistFun fun,  double *output) {
-    double val;
-    val = fun(data, dim[0], dim[1], dim[2], dim[3], output);
-}
-
-typedef double (*const CDistFun)(double* data, int r, int c, int i, int j, void *xdata);
-void const_distance(double *data, int *dim, CDistFun fun,  double *output) {
-    double val = fun(data, dim[0], dim[1], dim[2], dim[3], output);
 }
 
 typedef int (*Operator)(int i,int j);
@@ -40,18 +30,18 @@ int multiply(int a, int b) {
   return a*b;
 }
 
-int *nowt() {
+int *nowt() { 
   return 0;
 }
 
-int *nowt2(void) {
+int *nowt2(void) { 
   return 0;
 }
 
 struct MyStruct { int i; };
 typedef struct MyStruct * MyStructPtr;
 
-MyStructPtr mystructptr() {
+MyStructPtr mystructptr() { 
   return 0;
 }
 
@@ -67,22 +57,4 @@ void (*pfunc0)();
 int (*pfuncA)();
 void (*pfunc1)(int);
 void (*pfunc2)(int, double);
-
-#ifdef SWIGFORTRAN
-// Temporary example of setting function handles. This will be improved.
-%apply void* { SWIGTYPE (**)(ANY) } ;
-
-%typemap(fin) SWIGTYPE (**)(ANY) = FORTRAN_INTRINSIC_TYPE&;
-%typemap(ftype, in="type(C_FUNPTR), target, intent(inout)") SWIGTYPE (**)(ANY)
-  "type(C_FUNPTR), pointer"
-#endif
-
-void set_handle(int choice, Operator* op) {
-  switch (choice) {
-    case 0: *op = add; break;
-    case 1: *op = subtract; break;
-    case 2: *op = multiply; break;
-    default: *op = NULL;
-  }
-}
 %}

--- a/Lib/fortran/fortran.swg
+++ b/Lib/fortran/fortran.swg
@@ -97,6 +97,7 @@
 %include "classes.swg"
 %include "fundamental.swg"
 %include "enums.swg"
+%include "funptrs.swg"
 %include "fortranstrings.swg"
 %include "bindc.swg"
 

--- a/Lib/fortran/fortran.swg
+++ b/Lib/fortran/fortran.swg
@@ -46,6 +46,14 @@
 #define %nofortranbindc    %feature("fortran:bindc", "0")
 #define %clearfortranbindc %feature("fortran:bindc", "")
 
+#define %fortranbindc      %feature("fortran:bindc")
+#define %nofortranbindc    %feature("fortran:bindc", "0")
+#define %clearfortranbindc %feature("fortran:bindc", "")
+
+#define %fortrancallback      %feature("fortran:fortrancallback")
+#define %nofortrancallback    %feature("fortran:fortrancallback", "0")
+#define %clearfortrancallback %feature("fortran:fortrancallback", "")
+
 #define %fortransubroutine      %feature("fortran:subroutine")
 #define %nofortransubroutine    %feature("fortran:subroutine", "0")
 #define %clearfortransubroutine %feature("fortran:subroutine", "")

--- a/Lib/fortran/fortran.swg
+++ b/Lib/fortran/fortran.swg
@@ -50,9 +50,9 @@
 #define %nofortranbindc    %feature("fortran:bindc", "0")
 #define %clearfortranbindc %feature("fortran:bindc", "")
 
-#define %fortrancallback      %feature("fortran:fortrancallback")
-#define %nofortrancallback    %feature("fortran:fortrancallback", "0")
-#define %clearfortrancallback %feature("fortran:fortrancallback", "")
+#define %fortrancallback(X)   %feature("fortran:callback", `X`)
+#define %nofortrancallback    %feature("fortran:callback", "0")
+#define %clearfortrancallback %feature("fortran:callback", "")
 
 #define %fortransubroutine      %feature("fortran:subroutine")
 #define %nofortransubroutine    %feature("fortran:subroutine", "0")

--- a/Lib/fortran/fundamental.swg
+++ b/Lib/fortran/fundamental.swg
@@ -400,23 +400,6 @@ end subroutine}
 %apply SWIGTYPE* { bool& };
 
 /* -------------------------------------------------------------------------
- * FUNCTION POINTERS
- * ------------------------------------------------------------------------- */
-
-%apply void* { SWIGTYPE (*)(ANY) } ;
-
-%typemap(ctype) SWIGTYPE (*)(ANY)
-  "$1_ltype"
-%typemap(imtype, in="type(C_FUNPTR), value") SWIGTYPE (*)(ANY)
-  "type(C_FUNPTR)"
-%typemap(ftype, in="type(C_FUNPTR), intent(in), value") SWIGTYPE (*)(ANY)
-  "type(C_FUNPTR)"
-%typemap(bindc, in="type(C_FUNPTR), value") SWIGTYPE (*)(ANY)
-  "type(C_FUNPTR)"
-
-%apply SWIGTYPE (*)(ANY) { SWIGTYPE (* const)(ANY) } ;
-
-/* -------------------------------------------------------------------------
  * TYPE CHECKING
  * ------------------------------------------------------------------------- */
 

--- a/Lib/fortran/fundamental.swg
+++ b/Lib/fortran/fundamental.swg
@@ -148,7 +148,7 @@ SWIGINTERN SwigArrayWrapper SwigArrayWrapper_uninitialized() {
    %{FTYPE%}
   %typemap(ftype, in={FTYPE, intent(in)}) CTYPE
    %{FTYPE%}
-  %typemap(bindc, in={FTYPE, value}) CTYPE
+  %typemap(bindc, in={FTYPE, intent(in), value}) CTYPE
    %{FTYPE%}
   %typemap(in) CTYPE = FORTRAN_INTRINSIC_TYPE;
   %typemap(out) CTYPE = FORTRAN_INTRINSIC_TYPE;

--- a/Lib/fortran/funptrs.swg
+++ b/Lib/fortran/funptrs.swg
@@ -11,7 +11,7 @@
 %typemap(imtype, in="type(C_FUNPTR), value") SWIGTYPE (*)(ANY)
   "type(C_FUNPTR)"
 %typemap(ftype) SWIGTYPE (*)(ANY)
-  "procedure($fortranclassname)"
+  "procedure($*fortranclassname)"
 %typemap(bindc, in="type(C_FUNPTR), value") SWIGTYPE (*)(ANY)
   "type(C_FUNPTR)"
 

--- a/Lib/fortran/funptrs.swg
+++ b/Lib/fortran/funptrs.swg
@@ -17,12 +17,11 @@
 
 %typemap(in) SWIGTYPE (*)(ANY) = void *;
 %typemap(out) SWIGTYPE (*)(ANY) = void *;
-  
+
 %typemap(fin) SWIGTYPE (*)(ANY)
   "$1 = c_funloc($input)"
 %typemap(fout) SWIGTYPE (*)(ANY)
   "call c_f_procpointer($1, $result)"
-  
-%apply SWIGTYPE (*)(ANY) { SWIGTYPE (* const)(ANY) } ;
 
+%apply SWIGTYPE (*)(ANY) { SWIGTYPE (* const)(ANY) } ;
 

--- a/Lib/fortran/funptrs.swg
+++ b/Lib/fortran/funptrs.swg
@@ -1,0 +1,28 @@
+/* -------------------------------------------------------------------------
+ * funptrs.swg
+ *
+ * Function pointers
+ * ------------------------------------------------------------------------- */
+
+%apply void* { SWIGTYPE (*)(ANY) } ;
+
+%typemap(ctype) SWIGTYPE (*)(ANY)
+  "$1_ltype"
+%typemap(imtype, in="type(C_FUNPTR), value") SWIGTYPE (*)(ANY)
+  "type(C_FUNPTR)"
+%typemap(ftype, in="procedure($fortranclassname), intent(in)") SWIGTYPE (*)(ANY)
+  "procedure($fortranclassname)"
+%typemap(bindc, in="type(C_FUNPTR), value") SWIGTYPE (*)(ANY)
+  "type(C_FUNPTR)"
+
+%typemap(in) SWIGTYPE (*)(ANY) = void *;
+%typemap(out) SWIGTYPE (*)(ANY) = void *;
+  
+%typemap(fin) bool (*)(SWIGTYPE, SWIGTYPE)
+  "$1 = c_funloc($input)"
+%typemap(fout) bool (*)(CTYPE, CTYPE)
+  "call c_f_procpointer($1, $result)"
+  
+%apply SWIGTYPE (*)(ANY) { SWIGTYPE (* const)(ANY) } ;
+
+

--- a/Lib/fortran/funptrs.swg
+++ b/Lib/fortran/funptrs.swg
@@ -10,7 +10,7 @@
   "$1_ltype"
 %typemap(imtype, in="type(C_FUNPTR), value") SWIGTYPE (*)(ANY)
   "type(C_FUNPTR)"
-%typemap(ftype, in="procedure($fortranclassname), intent(in)") SWIGTYPE (*)(ANY)
+%typemap(ftype) SWIGTYPE (*)(ANY)
   "procedure($fortranclassname)"
 %typemap(bindc, in="type(C_FUNPTR), value") SWIGTYPE (*)(ANY)
   "type(C_FUNPTR)"
@@ -18,9 +18,9 @@
 %typemap(in) SWIGTYPE (*)(ANY) = void *;
 %typemap(out) SWIGTYPE (*)(ANY) = void *;
   
-%typemap(fin) bool (*)(SWIGTYPE, SWIGTYPE)
+%typemap(fin) SWIGTYPE (*)(ANY)
   "$1 = c_funloc($input)"
-%typemap(fout) bool (*)(CTYPE, CTYPE)
+%typemap(fout) SWIGTYPE (*)(ANY)
   "call c_f_procpointer($1, $result)"
   
 %apply SWIGTYPE (*)(ANY) { SWIGTYPE (* const)(ANY) } ;

--- a/Lib/fortran/funptrs.swg
+++ b/Lib/fortran/funptrs.swg
@@ -10,8 +10,8 @@
   "$1_ltype"
 %typemap(imtype, in="type(C_FUNPTR), value") SWIGTYPE (*)(ANY)
   "type(C_FUNPTR)"
-%typemap(ftype) SWIGTYPE (*)(ANY)
-  "procedure($*fortranclassname)"
+%typemap(ftype, in="procedure($*fortranclassname)") SWIGTYPE (*)(ANY)
+  "procedure($*fortranclassname), pointer"
 %typemap(bindc, in="type(C_FUNPTR), value") SWIGTYPE (*)(ANY)
   "type(C_FUNPTR)"
 

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -570,6 +570,7 @@ private:
   String *f_fbegin;      //!< Very beginning of output file
   String *f_fuse;        //!< Fortran "use" directives
   String *f_fdecl;       //!< Module declaration constructs
+  String *f_fabstract;   //!< Fortran "abstract interface" declarations
   String *f_finterfaces; //!< Fortran interface declarations to SWIG functions
   String *f_fsubprograms;    //!< Fortran subroutine wrapper functions
 
@@ -740,6 +741,10 @@ int FORTRAN::top(Node *n) {
   f_fdecl = NewStringEmpty();
   Swig_register_filebyname("fdecl", f_fdecl);
 
+  // Fortran BIND(C) abstract interfavces
+  f_fabstract = NewStringEmpty();
+  Swig_register_filebyname("fabstract", f_fabstract);
+
   // Fortran BIND(C) interfavces
   f_finterfaces = NewStringEmpty();
   Swig_register_filebyname("finterfaces", f_finterfaces);
@@ -882,6 +887,15 @@ void FORTRAN::write_module(String *filename) {
            NULL);
   }
 
+  if (Len(f_fabstract) > 0) {
+    Printv(out,
+           "\n! FUNCTION POINTER DECLARATIONS\n"
+           "abstract interface\n",
+           f_fabstract,
+           "end interface\n"
+           "\n",
+           NULL);
+  }
   if (Len(f_finterfaces) > 0) {
     Printv(out,
            "\n! WRAPPER DECLARATIONS\n"

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -1546,12 +1546,15 @@ Wrapper *FORTRAN::imfuncWrapper(Node *n, bool bindc) {
 
   // END FUNCTION DEFINITION
   print_wrapped_list(imfunc->def, First(imfunc_arglist), Len(imfunc->def));
-  Printv(imfunc->def,
-         ") &\n"
-         "    bind(C, name=\"",
-         Getattr(n, "wrap:name"),
-         "\")",
-         NULL);
+  Printv(imfunc->def, ") &\n    bind(C", NULL);
+
+  if (String *wname = Getattr(n, "wrap:name")) {
+    // Binding to an acutal function
+    Printv(imfunc->def, ", name=\"", wname, "\")", NULL);
+  } else {
+    // Creating an abstract interface
+    Printv(imfunc->def, ")", NULL);
+  }
 
   if (!is_imsubroutine) {
     // Declare dummy return value if it's a function

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -120,7 +120,7 @@ int fix_fortran_dims(Node *n, const char *tmap_name, String *typemap) {
   int ndim = SwigType_array_ndim(t);
   for (int i = 0; i < ndim; i++) {
     String *dim = SwigType_array_getdim(t, i);
-    if (dim && !is_fortran_intexpr(dim)) {
+    if (dim && Len(dim) > 0 && !is_fortran_intexpr(dim)) {
       Swig_warning(WARN_LANG_IDENTIFIER, input_file, line_number,
                    "Array dimension expression '%s' is incompatible with Fortran\n",
                    dim);
@@ -2864,7 +2864,6 @@ int FORTRAN::constantWrapper(Node *n) {
   // Save some properties that get temporarily changed
   Swig_save("constantWrapper", n, "wrap:name", "lname", "fortran:name", NULL);
 
-  String *nodetype = nodeType(n);
   String *value = NULL;
 
   if (String *override_value = Getattr(n, "feature:fortran:constvalue")) {
@@ -2874,6 +2873,7 @@ int FORTRAN::constantWrapper(Node *n) {
     value = Getattr(n, "rawval");
   }
 
+  String *nodetype = nodeType(n);
   if (Strcmp(nodetype, "enumitem") == 0) {
     // Set type from the parent enumeration
     // XXX why??


### PR DESCRIPTION
- Explicitly generate Fortran callback signatures using `%fortrancallback`.
- Function pointer wrapper code now  uses `$*fclassname` to determine a specific callback type that corresponds  to the function signature, rather than defaulting to the opaque `SWIGTYPE*`.
- If the callback function signature isn't defined, it will create a new abstract interface.

Closes  #116 .