### PR TITLE
Fix opaque type redefinition

### DIFF
--- a/Examples/test-suite/imports_a.h
+++ b/Examples/test-suite/imports_a.h
@@ -26,4 +26,11 @@ class A_Intermediate : public A {
   A_Intermediate(){}
   ~A_Intermediate(){}
 };
+
+// Declare an opaque type
+class Opaque;
+Opaque* get_opaque_null_a() { return NULL; }
+
+bool is_null_opaque(const Opaque* obj) { return (obj == NULL); }
+
 #endif

--- a/Examples/test-suite/imports_b.h
+++ b/Examples/test-suite/imports_b.h
@@ -29,3 +29,7 @@ struct C : A
   
 };
 
+// Declare the same opaque typename as in imports_a
+class Opaque;
+Opaque* get_opaque_null_b() { return NULL; }
+


### PR DESCRIPTION
This will be a fix for #141 when I figure it out. The commit on this branch is so far just a unit test  showing the failure.

Until then, it should be possible to work around the bug by hiding typemaps that have `$fortranclassname` in them in the downstream code, or wholesale applying another typemap.