### PR TITLE
Improve behavior of %constant

### DIFF
--- a/Doc/Manual/src/Fortran.md
+++ b/Doc/Manual/src/Fortran.md
@@ -1948,6 +1948,14 @@ To bind *all* functions as native C interfaces, use
 This is often useful when coupled with the `%fortranconst` directive (see
 the [enumerations](#enumerations) section).
 
+### Function pointers and callbacks
+
+The `%callback` feature is redundant and ignored for `%fortranbindc` types: a
+valid function pointer to the C function can be obtained simply with the
+`c_funptr` intrinsic function. Any `%fortrancallback` directives in the code
+will still generate abstract interfaces, but they will simply supplement the
+direct-bound C code 
+
 ### Generating C-bound Fortran types from C structs
 
 In certain circumstances, C++ structs can be wrapped natively as Fortran

--- a/Doc/Manual/src/Fortran.md
+++ b/Doc/Manual/src/Fortran.md
@@ -906,7 +906,9 @@ value as a native Fortran datatype. Constants can be declared with:
 - The SWIG `%constant` directive,
 - Simple `#define` macros, and
 - `constexpr` global variables.
-The last item is a SWIG-Fortran extension.
+The last item is a SWIG-Fortran extension. For an explanation of this behavior,
+see the "Compatibility note" under "A brief word about const" in the SWIG
+documentation.
 
 All global `const` variables will be treated as regular global variables: they
 will be wrapped with getter functions. SWIG-declared `%constant`s whose

--- a/Doc/Manual/src/Fortran.md
+++ b/Doc/Manual/src/Fortran.md
@@ -97,7 +97,7 @@ presents some equivalent concepts and names in the two languages:
 | arithmetic type                  | intrinsic type              |
 | derived type                     | extended type               |
 | function parameters              | dummy arguments             |
-| `constexpr` variable             | `parameter` statement       |
+| `constexpr` variable             | named constant              |
 
 ## Identifiers
 
@@ -557,8 +557,10 @@ constants that are guaranteed to be compatible with C enumerators. Unlike C++,
 all enumerators in Fortran are anonymous.
 
 To associate a C enumeration name with the Fortran
-generated wrappers, SWIG generates an integer parameter with the C enumeration
-name. The enumeration generated from the C code
+generated wrappers, SWIG generates a named constant with the C enumeration
+name whose value is the size of the enum that can then be used analogously to
+`C_INT`, which specifies the size of the native C integer type. 
+The enumeration generated from the C code
 ```c++
 enum MyEnum {
   RED = 0,
@@ -895,17 +897,22 @@ will generate a publicly accessible C-bound variable:
 integer(C_INT), public, bind(C, name="global_counter_c") :: global_counter_c
 ```
 
-### Global constants
+### Constants
 
-Global constant variables (whether declared in C++ headers with `const` or in
-a SWIG wrapper with `%constant`) of native types can be wrapped as Fortran
-"parameters" (compile-time values), as externally bound constants, or as
-wrapper functions that return the value.
+A constant declaration can be wrapped as a Fortran *named constant*
+(a compile-time value defined by having the `parameter` attribute), as
+an externally linked data object, or as a wrapper function that returns the
+value as a native Fortran datatype. Constants can be declared with:
+- The SWIG `%constant` directive,
+- Simple `#define` macros, and
+- `constexpr` global variables.
+The last item is a SWIG-Fortran extension.
 
-The default behavior is for global `const` variables, *or* `%constant`s whose
-data types cannot be [directly represented](#direct-c-binding), to be wrapped
-with getter functions. Variables marked with the `%fortranconst` directive are
-wrapped as Fortran `parameter` module values. If declaring a C-linkage
+All global `const` variables will be treated as regular global variables: they
+will be wrapped with getter functions. SWIG-declared `%constant`s whose
+data types cannot be [directly represented](#direct-c-binding) will be wrapped
+with getter functions. Constants marked with the `%fortranconst` directive are
+wrapped as Fortran module-level named constants. If declaring a C-linkage
 `%constant`, it is directly exposed to Fortran using `bind(C)`. Otherwise, a
 const global wrapper variable will be created in the C wrapper code and `bound`
 in the Fortran module.  

--- a/Examples/fortran/bare/example.h
+++ b/Examples/fortran/bare/example.h
@@ -52,21 +52,28 @@ void print_cmyk(CmykEnum color);
 /* -------------------------------------------------------------------------
  * Global variables
  * ------------------------------------------------------------------------- */
+#if __cplusplus >= 201103
+#define CONSTEXPR constexpr
+#elif defined(SWIG)
+#define CONSTEXPR %constant
+#else
+#define CONSTEXPR const
+#endif
 
 //! An integer that is only known at link time
 extern const int linked_const_int;
 
 //! A simple integer
-const int simple_int = 4;
+CONSTEXPR int simple_int = 4;
 
 // A more complicated integer
-const int weird_int = (0x1337 | 0x10000);
+CONSTEXPR int weird_int = (0x1337 | 0x10000);
 
 //! A global constant wrapped as a native parameter
-const double approx_pi = 3.14160000001;
+CONSTEXPR double approx_pi = 3.14160000001;
 
 //! A global constant wrapped as a protected external variable
-const double approx_twopi = 2 * approx_pi;
+CONSTEXPR double approx_twopi = 2 * approx_pi;
 
 //! A global variable
 namespace foo {

--- a/Examples/fortran/bare/example.i
+++ b/Examples/fortran/bare/example.i
@@ -5,24 +5,28 @@
 #include "example.h"
 %}
 
-//! A const integer
-// const int param_int = 4;
-// const int wrapped_int = 0x1337;
+#ifdef SWIGFORTRAN
+// Force constants to be a compile-time native fortran parameter
+%fortranconst param_const;
+%fortranconst MY_SPECIAL_NUMBERS;
+%fortranconst approx_pi;
+%fortranconst so_excited;
+// Force constants to be defined in C++ but can be directly referenced in Fortran as link-time immutable variables
+%fortranbindc octal_const;
+%fortranbindc wrapped_const;
+%fortranbindc weird_int;
+#endif
 
+
+// Compile-time/link-time constants
 #define MY_SPECIAL_NUMBERS 5
 %constant int param_const = 911;
 %constant int octal_const = 0777;
 %constant int wrapped_const = 0xdeadbeef;
-
-// Force a constant to be a compile-time native fortran parameter
-%fortranconst approx_pi;
-
-#ifdef SWIGFORTRAN
+%constant so_excited = "wheee";
 
 // Ignore one of the functions that can't be overloaded correctly
 %ignore cannot_overload(int);
-
-#endif
 
 %include "example.h"
 

--- a/Examples/fortran/bare/runme.f90
+++ b/Examples/fortran/bare/runme.f90
@@ -53,6 +53,7 @@ subroutine test_consts()
   write(STDOUT, *) "pi is approximately ", approx_pi
   write(STDOUT, *) "2pi is approximately ", get_approx_twopi()
   write(STDOUT, *) "extern const int is ", get_linked_const_int()
+  write(STDOUT, *) so_excited
   ! Can't assign these
 !   wrapped_const = 2
 !   MY_SPECIAL_NUMBERS = 4

--- a/Examples/fortran/funcptr/runme.f90
+++ b/Examples/fortran/funcptr/runme.f90
@@ -31,11 +31,11 @@ program fortran_funptr_runme
   integer(C_INT) :: b = 3
   procedure(binary_op), pointer :: fptr => null()
 
-  call c_f_procpointer(add, fptr)
+  fptr => get_ADD()
   write(STDOUT,*) "SWIG-wrapped C function pointer:", do_op(a, b, fptr)
-  call c_f_procpointer(sub, fptr)                                 
+  fptr => get_SUB()
   write(STDOUT,*) "SWIG-wrapped C function pointer:", do_op(a, b, fptr)
-  call c_f_procpointer(mul, fptr)                                 
+  fptr => get_MUL()
   write(STDOUT,*) "SWIG-wrapped C function pointer:", do_op(a, b, fptr)
 
   ! Convert Fortran function to C function pointer

--- a/Examples/test-suite/fortran/arrays_global_twodim_runme.F90
+++ b/Examples/test-suite/fortran/arrays_global_twodim_runme.F90
@@ -18,17 +18,19 @@ subroutine test_int_array
   integer(C_INT) :: cnt = 10
   integer(C_INT) :: x, y
   integer(C_INT), dimension(:,:), allocatable :: expected, actual
+  integer(C_INT), dimension(2) :: dims
 
+  dims = [get_ARRAY_LEN_Y(), get_ARRAY_LEN_X()]
   constintarray2d = get_array_const_i()
   intarray2d = get_array_i()
 
   call set_array_i(constintarray2d)
 
-  allocate(expected(ARRAY_LEN_Y, ARRAY_LEN_X))
-  allocate(actual(ARRAY_LEN_Y, ARRAY_LEN_X))
+  allocate(expected(dims(1), dims(2)))
+  allocate(actual(dims(1), dims(2)))
 
-  do x = 1, ARRAY_LEN_X
-    do y = 1, ARRAY_LEN_Y
+  do x = 1, dims(2)
+    do y = 1, dims(1)
       expected(y, x) = cnt
       cnt = cnt + 1
       actual(y, x) = get_2d_array(intarray2d, x - 1, y - 1)

--- a/Examples/test-suite/fortran/fortran_bindc_runme.F90
+++ b/Examples/test-suite/fortran/fortran_bindc_runme.F90
@@ -10,6 +10,7 @@ program fortran_bindc_runme
   call test_twod_unknown_int
   call test_fundamental
   call test_opaque_struct
+  call test_strings
 
 contains
 
@@ -102,6 +103,25 @@ subroutine test_opaque_struct
 
   s = make_intstruct(1234_c_int)
   ASSERT(1234_c_int == get_instruct_i(s))
+
+end subroutine
+
+subroutine test_strings
+  use fortran_bindc
+  use ISO_C_BINDING
+  implicit none
+  type(C_PTR) :: cptr
+  character(kind=c_char, len=:), pointer :: cstrptr
+  character(kind=c_char, len=*), parameter :: mystring = "I'm a string!"
+
+  ASSERT(strlen(mystring // C_NULL_CHAR) == len(mystring))
+
+  ! Note: not sure if the C-to-Fortran here is truly defined behavior
+  cptr = getstr(1)
+  call c_f_pointer(cptr, cstrptr)
+  ASSERT(associated(cstrptr))
+  ASSERT(strlen(cstrptr) == 3)
+  ASSERT(cstrptr(1:3) == "one")
 
 end subroutine
 

--- a/Examples/test-suite/fortran/fortran_bindc_runme.F90
+++ b/Examples/test-suite/fortran/fortran_bindc_runme.F90
@@ -110,18 +110,22 @@ subroutine test_strings
   use fortran_bindc
   use ISO_C_BINDING
   implicit none
+  character(kind=c_char, len=*), parameter :: mystring = "I'm a string!"
+#if __GNUC__ >= 9
   type(C_PTR) :: cptr
   character(kind=c_char, len=:), pointer :: cstrptr
-  character(kind=c_char, len=*), parameter :: mystring = "I'm a string!"
+#endif
 
   ASSERT(strlen(mystring // C_NULL_CHAR) == len(mystring))
 
-  ! Note: not sure if the C-to-Fortran here is truly defined behavior
+#if __GNUC__ >= 9
+  ! Note: this seems to be allowed in GCC 9 but not before. I'm not sure that it's the correct behavior.
   cptr = getstr(1)
   call c_f_pointer(cptr, cstrptr)
   ASSERT(associated(cstrptr))
   ASSERT(strlen(cstrptr) == 3)
   ASSERT(cstrptr(1:3) == "one")
+#endif
 
 end subroutine
 

--- a/Examples/test-suite/fortran/fortran_callback_c_runme.F90
+++ b/Examples/test-suite/fortran/fortran_callback_c_runme.F90
@@ -1,0 +1,75 @@
+! File : fortran_callback_c_c_runme.F90
+
+#include "fassert.h"
+
+module fortran_callback_c_mod
+  use, intrinsic :: ISO_C_BINDING
+  use ISO_FORTRAN_ENV
+  implicit none
+  integer, parameter :: STDOUT = OUTPUT_UNIT
+  integer(C_INT), save, public :: module_int
+contains
+
+function myexp(left, right) bind(C) &
+    result(fresult)
+  use, intrinsic :: ISO_C_BINDING
+  integer(C_INT), intent(in), value :: left
+  integer(C_INT), intent(in), value :: right
+  integer(C_INT) :: fresult
+
+  fresult = left ** right
+end function
+  
+function mywrite() bind(C) &
+    result(fresult)
+  use, intrinsic :: ISO_C_BINDING
+  integer(C_INT) :: fresult
+  ! write(STDOUT,*) "Hi there"
+  fresult = 256_c_int
+end function
+
+subroutine store_an_int(i) bind(C)
+  use, intrinsic :: ISO_C_BINDING
+  integer(C_INT), value, intent(in) :: i
+  ! write(STDOUT,*) "Got an integer: ", i
+  module_int = i
+end subroutine
+  
+end module
+
+program fortran_callback_c_runme
+  call test_callback
+contains
+
+subroutine test_callback
+  use fortran_callback_c
+  use fortran_callback_c_mod
+  integer(C_INT) :: i
+  procedure(binary_op), pointer :: bin_op_ptr => NULL()
+
+  ! Use callbacks with Fortran module pointers
+  bin_op_ptr => myexp
+  i = call_binary(c_funloc(myexp), 2, 3)
+  ASSERT(i == 8)
+  i = call_things(c_funloc(mywrite))
+  ASSERT(i == 256)
+  call also_call_things(c_funloc(store_an_int), 999)
+  ASSERT(module_int == 999)
+
+  ! Get a C function pointer to a bind(c) interface function
+  i = call_binary(c_funloc(mul), 3, 7)
+  ASSERT(i == 21)
+
+  ! Get a C callback
+  call c_f_procpointer(get_a_callback("mul"), bin_op_ptr)
+  ASSERT(associated(bin_op_ptr))
+  ASSERT(bin_op_ptr(2, 5) == 10)
+
+  call c_f_procpointer(get_a_callback("add"), bin_op_ptr)
+  ASSERT(associated(bin_op_ptr))
+  ASSERT(bin_op_ptr(2, 5) == 7)
+
+end subroutine
+end program
+
+

--- a/Examples/test-suite/fortran/fortran_callback_runme.F90
+++ b/Examples/test-suite/fortran/fortran_callback_runme.F90
@@ -61,6 +61,10 @@ subroutine test_callback
   bin_op_ptr => get_a_callback("mul")
   ASSERT(associated(bin_op_ptr))
   ASSERT(bin_op_ptr(2, 5) == 10)
+  ! Get from the %callback-generated wrapper
+  bin_op_ptr => get_mul_cb()
+  ASSERT(associated(bin_op_ptr))
+  ASSERT(bin_op_ptr(2, 5) == 10)
 
   bin_op_ptr => get_a_callback("add")
   ASSERT(associated(bin_op_ptr))

--- a/Examples/test-suite/fortran/fortran_global_const_runme.F90
+++ b/Examples/test-suite/fortran/fortran_global_const_runme.F90
@@ -29,10 +29,10 @@ subroutine test_constants
   ASSERT(all(compiletime_floats == 1.23))
 
   allocate(runtime_ints(3), source= &
-    [nofortranconst_int_global, MACRO_INT, &
+    [get_nofortranconst_int_global(), MACRO_INT, &
     get_extern_const_int()])
   allocate(runtime_floats(2), source= &
-    [constant_float_global, nofortranconst_float_global])
+    [constant_float_global, get_nofortranconst_float_global()])
 
   ASSERT(all(runtime_ints == 4))
   ASSERT(all(runtime_floats == 1.23))

--- a/Examples/test-suite/fortran/multi_import_runme.F90
+++ b/Examples/test-suite/fortran/multi_import_runme.F90
@@ -5,7 +5,7 @@
 program imports_runme
   use multi_import_a, only : ZZZ
   use multi_import_b, only : YYY
-  use multi_import_d, only : myval
+  use multi_import_d, only : get_myval
   use ISO_C_BINDING
   implicit none
   type(ZZZ) :: z
@@ -21,6 +21,6 @@ program imports_runme
   ASSERT(y%testx() == 0)
   call y%release()
 
-  ASSERT(myval == 1234)
+  ASSERT(get_myval() == 1234)
 
 end program

--- a/Examples/test-suite/fortran/string_constants_runme.F90
+++ b/Examples/test-suite/fortran/string_constants_runme.F90
@@ -1,0 +1,32 @@
+! File : string_constants_runme.F90
+
+#include "fassert.h"
+
+program string_constants_runme
+  use string_constants
+  use ISO_C_BINDING
+  implicit none
+  type(things) :: foo
+  ! note: Z'deadbeef' and O'777' are used to generate hex and oct constants
+  character(C_CHAR), parameter :: CR = char(Z'0D', C_CHAR)
+  character(C_CHAR), parameter :: LF = char(O'12', C_CHAR)
+  character(kind=C_CHAR, len=*), parameter :: &
+    expected_aa3 = "A" // CR // "B" // LF // "C"
+  character(kind=C_CHAR, len=:), allocatable :: actual_aa3
+  integer :: i
+
+  ASSERT(EE1 == "TUV")
+  ASSERT(XX2 == "WXY")
+  allocate(actual_aa3, source=get_AA3())
+
+  ! write(*,*) (iachar(actual_aa3(i:i)), i=1,len(actual_aa3))
+  ! write(*,*) (iachar(expected_aa3(i:i)), i=1,len(expected_aa3))
+
+  ASSERT(actual_aa3 == expected_aa3)
+  ASSERT(get_ZS3() == "")
+
+  foo = things()
+  ASSERT(foo%defarguments3() == "TUV")
+  call foo%release()
+end program
+

--- a/Examples/test-suite/fortran_bindc.i
+++ b/Examples/test-suite/fortran_bindc.i
@@ -1,7 +1,6 @@
 %module fortran_bindc
 
 %rename(RenamedOtherStruct) OtherStruct;
-%warnfilter(SWIGWARN_TYPEMAP_CHARLEAK) SimpleStruct::s; /* Setting a const char * variable may leak memory. */
 
 // Treat the struct as a native fortran struct rather than as a class with
 // getters/setters.

--- a/Examples/test-suite/fortran_bindc.i
+++ b/Examples/test-suite/fortran_bindc.i
@@ -200,3 +200,37 @@ int get_instruct_i(IntStruct* s) {
   return s->i;
 }
 %}
+
+// Character strings
+%{
+#include <string.h>
+%}
+
+%fortranbindc strlen;
+%fortranbindc getstr;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+int strlen(const char *s);
+#ifdef __cplusplus
+}
+#endif
+
+%inline %{
+#ifdef __cplusplus
+extern "C" {
+#endif
+const char* getstr(int choice) {
+  switch(choice) {
+    case 0: return "zero";
+    case 1: return "one";
+    case 2: return "two";
+  }
+  return "unknown";
+}
+#ifdef __cplusplus
+}
+#endif
+%}
+

--- a/Examples/test-suite/fortran_callback.i
+++ b/Examples/test-suite/fortran_callback.i
@@ -74,3 +74,23 @@ binary_op_cb get_a_callback(const char* name) {
 
 %}
 
+%warnfilter(SWIGWARN_TYPEMAP_UNDEF,SWIGWARN_LANG_NATIVE_UNIMPL) execute;
+
+// Opaque callback
+%{
+#ifdef __cplusplus
+extern "C" {
+#endif
+typedef struct { int i; } Foo;
+#ifdef __cplusplus
+}
+#endif
+%}
+
+%inline %{
+typedef int (*take_foo)(Foo);
+
+void execute(take_foo fptr, Foo f) {
+  (*fptr)(f);
+}
+%}

--- a/Examples/test-suite/fortran_callback.i
+++ b/Examples/test-suite/fortran_callback.i
@@ -1,10 +1,5 @@
 %module fortran_callback
 
-#ifndef __cplusplus
-// Directly bind all functions: don't create proxy wrappers
-%fortranbindc;
-#endif
-
 // Declare callback signature
 %fortrancallback("%s");
 #ifdef __cplusplus
@@ -18,7 +13,7 @@ void stupider_op();
 #endif
 %nofortrancallback;
 
-// Create callbacks and define functions
+// Create callbacks and define functions *unless using bindc*
 %callback("%s_cb");
 
 %inline %{
@@ -73,7 +68,7 @@ binary_op_cb get_a_callback(const char* name) {
   } if (strcmp(name, "mul") == 0) {
     return &mul;
   }
-  printf("Invalid callback name '%s'\n", name);
+  // printf("Invalid callback name '%s'\n", name);
   return NULL;
 }
 

--- a/Examples/test-suite/fortran_callback.i
+++ b/Examples/test-suite/fortran_callback.i
@@ -94,3 +94,18 @@ void execute(take_foo fptr, Foo f) {
   (*fptr)(f);
 }
 %}
+
+#ifdef __cplusplus
+
+%warnfilter(SWIGWARN_TYPEMAP_UNDEF,SWIGWARN_LANG_NATIVE_UNIMPL) execute_bar;
+
+%inline %{
+class Bar {};
+
+typedef int (*take_bar)(Bar);
+
+void execute_bar(take_bar fptr, Bar b) {
+  (*fptr)(b);
+}
+%}
+#endif

--- a/Examples/test-suite/fortran_callback_c.i
+++ b/Examples/test-suite/fortran_callback_c.i
@@ -1,4 +1,10 @@
 %module fortran_callback_c
 
+%fortranbindc;
+
+// Ignore warning about callbacks (since we're doing fortranbindc for everything)
+%warnfilter(SWIGWARN_FORTRAN_IGNORE_CALLBACK) add;
+%warnfilter(SWIGWARN_FORTRAN_IGNORE_CALLBACK) mul;
+
 %include "fortran_callback.i"
 

--- a/Examples/test-suite/fortran_global_const.i
+++ b/Examples/test-suite/fortran_global_const.i
@@ -1,19 +1,22 @@
 %module fortran_global_const
 
+// Wrap as 'parameters'
 %fortranconst fortranconst_int_global;
 %fortranconst fortranconst_float_global;
 %constant int fortranconst_int_global = 4;
 %constant float fortranconst_float_global = 1.23f;
 
-// Neither of these is wrapped as native constants (disabled by default)
+// Wrap as externally-linked constants
+%fortranbindc constant_int_global;
+%fortranbindc constant_float_global;
 %constant int constant_int_global = 4;
 %constant float constant_float_global = 1.23f;
 
-%nofortranconst nofortranconst_int_global;
-%nofortranconst nofortranconst_float_global;
+// Default wrapping: getters
 %constant int nofortranconst_int_global = 4;
 %constant float nofortranconst_float_global = 1.23f;
 
+%fortranbindc MACRO_INT;
 %fortranconstvalue(4) MACRO_HEX_INT;
 
 %inline %{

--- a/Examples/test-suite/fortran_naming.i
+++ b/Examples/test-suite/fortran_naming.i
@@ -18,6 +18,8 @@
 %rename(m_x) MyStruct::_x;
 %rename(m_y) MyStruct::_y;
 
+%fortranconst _123;
+
 %inline %{
 // Forward-declare and operate on pointer
 class _Foo;
@@ -107,6 +109,7 @@ extern "C" int _0cboundfunc(const int _x) { return _x + 1; }
 
 %}
 
+%fortranconst;
 // This name is too long
 %constant int sixty_four_characters_is_way_too_long_for_fortran_or_punch_cards = 64;
 // This name shows that you can't simply truncate
@@ -115,6 +118,7 @@ extern "C" int _0cboundfunc(const int _x) { return _x + 1; }
 // This name is the maximum length but starts with an underscore
 %constant int _leading_underscore_with_sixty_four_characters_is_just_darn_long = 64;
 %constant int _leading_underscore_with_sixty_three_characters_might_be_tricky = 63;
+%nofortranconst;
 
 // This class is poorly named, but the symname is OK.
 %inline %{

--- a/Examples/test-suite/string_constants.i
+++ b/Examples/test-suite/string_constants.i
@@ -11,6 +11,9 @@
 #if defined(SWIGJAVA)
 %javaconst(1);
 #endif
+#if defined(SWIGFORTRAN)
+%fortranconst;
+#endif
 %inline %{
 #define SS1 "ÆÎOU\n"
 #define AA1 "A\rB\nC"

--- a/Lib/fortran/bindc.swg
+++ b/Lib/fortran/bindc.swg
@@ -4,7 +4,7 @@
 
 // Declare a generic `FORTRAN_STRUCT_TYPE` as a native type.
 // Rather than being an intrinsic type `integer(C_INT)` it's a derived type `type($fortranclassname)`
-%fortran_intrinsic(FORTRAN_STRUCT_TYPE, type($fortranclassname))
+%fortran_intrinsic(FORTRAN_STRUCT_TYPE, type, $fortranclassname)
 // Avoid 'C99 forbids casting nonscalar type 'XY' to the same type'
 %typemap(in) FORTRAN_STRUCT_TYPE "$1 = *$input;"
 %typemap(out) FORTRAN_STRUCT_TYPE "$result = $1;"

--- a/Lib/fortran/fortranstrings.swg
+++ b/Lib/fortran/fortranstrings.swg
@@ -100,7 +100,8 @@ end subroutine
 %typemap(bindc, in="character(kind=C_CHAR, len=*)") char *
   "type(C_PTR)";
 
-%typemap(bindc, in="character(kind=C_CHAR), dimension(*), intent(in)") const char *
+%typemap(bindc, in="character(kind=C_CHAR), dimension(*), intent(in)",
+         fortranconst="character(kind=C_CHAR, len=*)") const char *
   "type(C_PTR)";
 
 /* -------------------------------------------------------------------------

--- a/Lib/fortran/fortranstrings.swg
+++ b/Lib/fortran/fortranstrings.swg
@@ -97,6 +97,12 @@ end subroutine
   if ($owner) call SWIG_free($1%data)
 }
 
+%typemap(bindc, in="character(kind=C_CHAR, len=*)") char *
+  "type(C_PTR)";
+
+%typemap(bindc, in="character(kind=C_CHAR), dimension(*), intent(in)") const char *
+  "type(C_PTR)";
+
 /* -------------------------------------------------------------------------
  * BYTE ARRAY TYPEMAPS
  *

--- a/Lib/fortran/fundamental.swg
+++ b/Lib/fortran/fundamental.swg
@@ -138,18 +138,18 @@ SWIGINTERN SwigArrayWrapper SwigArrayWrapper_uninitialized() {
  * that we can get the C location of the input array directly.
  *
  */
-%define %fortran_intrinsic(CTYPE, FTYPE)
+%define %fortran_intrinsic(CTYPE, FTYPE, FKIND)
   %fortran_apply_typemaps(FORTRAN_INTRINSIC_TYPE, CTYPE)
   
   // Regular values are passed as pointers and returned by value
   %typemap(ctype, in={const CTYPE*}) CTYPE
    %{CTYPE%}
-  %typemap(imtype, in={FTYPE, intent(in)}) CTYPE
-   %{FTYPE%}
-  %typemap(ftype, in={FTYPE, intent(in)}) CTYPE
-   %{FTYPE%}
-  %typemap(bindc, in={FTYPE, intent(in), value}) CTYPE
-   %{FTYPE%}
+  %typemap(imtype, in={FTYPE(FKIND), intent(in)}) CTYPE
+   %{FTYPE(FKIND)%}
+  %typemap(ftype, in={FTYPE(FKIND), intent(in)}) CTYPE
+   %{FTYPE(FKIND)%}
+  %typemap(bindc, in={FTYPE(FKIND), intent(in), value}, kind={FKIND}) CTYPE
+   %{FTYPE(FKIND)%}
   %typemap(in) CTYPE = FORTRAN_INTRINSIC_TYPE;
   %typemap(out) CTYPE = FORTRAN_INTRINSIC_TYPE;
   %typemap(fin) CTYPE = FORTRAN_INTRINSIC_TYPE;
@@ -159,17 +159,16 @@ SWIGINTERN SwigArrayWrapper SwigArrayWrapper_uninitialized() {
   %typemap(fout) CTYPE = FORTRAN_INTRINSIC_TYPE;
 
   %typemap(bindc) CTYPE* = FORTRAN_INTRINSIC_TYPE*;
-  %typemap(bindc) const CTYPE* = const FORTRAN_INTRINSIC_TYPE*;
 
   // Fragment for converting array to array wrapper. This needs the intermediate step of assigning the first element to an array pointer to be compatible with
   // ISO C.
   %fragment("SWIG_fin"{CTYPE[]}, "fsubprograms", fragment="SwigArrayWrapper_f", noblock=1)
 {subroutine %fortrantm(fin, CTYPE[])(finp, iminp)
   use, intrinsic :: ISO_C_BINDING
-  FTYPE, dimension(:), intent(in), target :: finp
+  FTYPE(FKIND), dimension(:), intent(in), target :: finp
   type(SwigArrayWrapper), intent(out) :: iminp
   integer(C_SIZE_T) :: sz
-  FTYPE, pointer :: imtemp
+  FTYPE(FKIND), pointer :: imtemp
 
   sz = size(finp, kind=C_SIZE_T)
   if (sz > 0_c_size_t) then
@@ -186,7 +185,7 @@ end subroutine}
   {subroutine %fortrantm(fout, CTYPE[])(imout, fout)
   use, intrinsic :: ISO_C_BINDING
   type(SwigArrayWrapper), intent(in) :: imout
-  FTYPE, dimension(:), pointer, intent(out) :: fout
+  FTYPE(FKIND), dimension(:), pointer, intent(out) :: fout
 
   if (imout%size > 0) then
     call c_f_pointer(imout%data, fout, [imout%size])
@@ -341,15 +340,15 @@ end subroutine}
  * ------------------------------------------------------------------------- */
 
 // Fundamental ISO-C binding types
-%fortran_intrinsic(signed char, integer(C_SIGNED_CHAR))
-%fortran_intrinsic(short      , integer(C_SHORT)      )
-%fortran_intrinsic(int        , integer(C_INT)        )
-%fortran_intrinsic(long       , integer(C_LONG)       )
-%fortran_intrinsic(long long  , integer(C_LONG_LONG)  )
-%fortran_intrinsic(size_t     , integer(C_SIZE_T)     )
-%fortran_intrinsic(float      , real(C_FLOAT)         )
-%fortran_intrinsic(double     , real(C_DOUBLE)        )
-%fortran_intrinsic(char       , character(C_CHAR)     )
+%fortran_intrinsic(signed char, integer  , C_SIGNED_CHAR)
+%fortran_intrinsic(short      , integer  , C_SHORT)
+%fortran_intrinsic(int        , integer  , C_INT)
+%fortran_intrinsic(long       , integer  , C_LONG)
+%fortran_intrinsic(long long  , integer  , C_LONG_LONG)
+%fortran_intrinsic(size_t     , integer  , C_SIZE_T)
+%fortran_intrinsic(float      , real     , C_FLOAT)
+%fortran_intrinsic(double     , real     , C_DOUBLE)
+%fortran_intrinsic(char       , character, C_CHAR)
 
 // Unsigned integer types
 %fortran_unsigned(signed char     ,unsigned char      )
@@ -359,7 +358,7 @@ end subroutine}
 %fortran_unsigned(signed long long,unsigned long long )
 
 // Pointer type
-%fortran_intrinsic(void*, type(C_PTR))
+%fortran_intrinsic(void*, type, C_PTR)
 
 /* -------------------------------------------------------------------------
  * LOGICAL (BOOLEAN) TYPE

--- a/Lib/fortran/fundamental.swg
+++ b/Lib/fortran/fundamental.swg
@@ -149,7 +149,7 @@ SWIGINTERN SwigArrayWrapper SwigArrayWrapper_uninitialized() {
   %typemap(ftype, in={FTYPE(FKIND), intent(in)}) CTYPE
    %{FTYPE(FKIND)%}
   %typemap(bindc, in={FTYPE(FKIND), intent(in), value}, kind={FKIND},
-           constant={FTYPE(FKIND)}) CTYPE
+           fortranconst={FTYPE(FKIND)}) CTYPE
    %{FTYPE(FKIND)%}
   %typemap(in) CTYPE = FORTRAN_INTRINSIC_TYPE;
   %typemap(out) CTYPE = FORTRAN_INTRINSIC_TYPE;

--- a/Lib/fortran/fundamental.swg
+++ b/Lib/fortran/fundamental.swg
@@ -148,7 +148,8 @@ SWIGINTERN SwigArrayWrapper SwigArrayWrapper_uninitialized() {
    %{FTYPE(FKIND)%}
   %typemap(ftype, in={FTYPE(FKIND), intent(in)}) CTYPE
    %{FTYPE(FKIND)%}
-  %typemap(bindc, in={FTYPE(FKIND), intent(in), value}, kind={FKIND}) CTYPE
+  %typemap(bindc, in={FTYPE(FKIND), intent(in), value}, kind={FKIND},
+           constant={FTYPE(FKIND)}) CTYPE
    %{FTYPE(FKIND)%}
   %typemap(in) CTYPE = FORTRAN_INTRINSIC_TYPE;
   %typemap(out) CTYPE = FORTRAN_INTRINSIC_TYPE;

--- a/Lib/fortran/stdint.i
+++ b/Lib/fortran/stdint.i
@@ -7,21 +7,21 @@
 
 %include <fundamental.swg>
 
-%fortran_intrinsic(int8_t,  integer(C_INT8_T))
-%fortran_intrinsic(int16_t, integer(C_INT16_T))
-%fortran_intrinsic(int32_t, integer(C_INT32_T))
-%fortran_intrinsic(int64_t, integer(C_INT64_T))
+%fortran_intrinsic(int8_t,  integer, C_INT8_T)
+%fortran_intrinsic(int16_t, integer, C_INT16_T)
+%fortran_intrinsic(int32_t, integer, C_INT32_T)
+%fortran_intrinsic(int64_t, integer, C_INT64_T)
 
-%fortran_intrinsic(int_least8_t,  integer(C_INT_LEAST8_T))
-%fortran_intrinsic(int_least16_t, integer(C_INT_LEAST16_T))
-%fortran_intrinsic(int_least32_t, integer(C_INT_LEAST32_T))
-%fortran_intrinsic(int_least64_t, integer(C_INT_LEAST64_T))
+%fortran_intrinsic(int_least8_t,  integer, C_INT_LEAST8_T)
+%fortran_intrinsic(int_least16_t, integer, C_INT_LEAST16_T)
+%fortran_intrinsic(int_least32_t, integer, C_INT_LEAST32_T)
+%fortran_intrinsic(int_least64_t, integer, C_INT_LEAST64_T)
 
-%fortran_intrinsic(int_fast8_t,  integer(C_INT_FAST8_T))
-%fortran_intrinsic(int_fast16_t, integer(C_INT_FAST16_T))
-%fortran_intrinsic(int_fast32_t, integer(C_INT_FAST32_T))
-%fortran_intrinsic(int_fast64_t, integer(C_INT_FAST64_T))
+%fortran_intrinsic(int_fast8_t,  integer, C_INT_FAST8_T)
+%fortran_intrinsic(int_fast16_t, integer, C_INT_FAST16_T)
+%fortran_intrinsic(int_fast32_t, integer, C_INT_FAST32_T)
+%fortran_intrinsic(int_fast64_t, integer, C_INT_FAST64_T)
 
-%fortran_intrinsic(intmax_t, integer(C_INTMAX_T))
-%fortran_intrinsic(intptr_t, integer(C_INTPTR_T))
+%fortran_intrinsic(intmax_t, integer, C_INTMAX_T)
+%fortran_intrinsic(intptr_t, integer, C_INTPTR_T)
 

--- a/Source/Include/swigwarn.h
+++ b/Source/Include/swigwarn.h
@@ -260,6 +260,7 @@
 #define WARN_FORTRAN_COVARIANT_RET          767
 #define WARN_FORTRAN_NO_SUBROUTINE          768
 #define WARN_FORTRAN_ARGUMENT_NAME          769
+#define WARN_FORTRAN_IGNORE_CALLBACK        770
 
 /* please leave 760-779 free for Fortran */
 

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -2471,12 +2471,10 @@ int FORTRAN::globalfunctionHandler(Node *n) {
 
   if (GetFlag(n, "feature:fortran:bindc")) {
     if (GetFlagAttr(n, "feature:callback")) {
-      Swig_error(input_file,
+      Swig_warning(WARN_FORTRAN_IGNORE_CALLBACK, input_file,
                  line_number,
-                 "Using %%fortranbindc and %%callback on the same function "
-                 "is not supported.\n",
+                 "Ignoring %%callback for %%fortranbindc function '%s'\n",
                  Getattr(n, "sym:name"));
-      return SWIG_ERROR;
     }
     // The wrapped function name *is* the C function name
     Setattr(n, "wrap:name", Getattr(n, "name"));

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -2877,8 +2877,8 @@ int FORTRAN::constantWrapper(Node *n) {
 
   // Get Fortran data type
   Swig_typemap_lookup("bindc", n, Getattr(n, "name"), NULL);
-  String *bindc_typestr = Getattr(n, "tmap:bindc:fortranconst");
   bool is_native_constant = GetFlagAttr(n, "feature:fortran:const");
+  String *bindc_typestr = is_native_constant ? Getattr(n, "tmap:bindc:fortranconst") : Getattr(n, "tmap:bindc");
 
   // Check for missing typemap
   if (!bindc_typestr) {

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -2762,6 +2762,8 @@ int FORTRAN::enumDeclaration(Node *n) {
     } else {
       Setattr(c, "fortran:name", child_fsymname);
     }
+    // Force enum to have integer type
+    Setattr(c, "type", "int");
     // Add enum name to the symtab
     Setattr(fsymtab, lower_fsymname, n);
     Delete(lower_fsymname);

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -2441,6 +2441,9 @@ int FORTRAN::membervariableHandler(Node *n) {
 int FORTRAN::globalvariableHandler(Node *n) {
   if (GetFlag(n, "feature:fortran:bindc")) {
     return this->bindcvarWrapper(n);
+  } else if (GetFlagAttr(n, "feature:fortran:const") && Strcmp(Getattr(n, "storage"), "constexpr") == 0) {
+    // constexpr global variable
+    return this->constantWrapper(n);
   }
 
   // No special cases: treat like a global variable

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -1928,8 +1928,14 @@ int FORTRAN::bindcvarWrapper(Node *n) {
   
   String *name = Getattr(n, "name");
   ASSERT_OR_PRINT_NODE(name, n);
+  ASSERT_OR_PRINT_NODE(Getattr(n, "type"), n);
+
+  const char* protection_str = "";
+  if (strncmp(Char(Getattr(n, "type")), "q(const)", 8) == 0) { 
+    protection_str = "protected, ";
+  }
   
-  Printv(f_fdecl, " ", bindc_typestr, ", public, &\n",
+  Printv(f_fdecl, " ", bindc_typestr, ", public, ", protection_str, "&\n",
          "   bind(C, name=\"", name, "\") :: ",
          (Len(name) > 60 ? "&\n    " : ""),
          fsymname, "\n",
@@ -2427,18 +2433,10 @@ int FORTRAN::membervariableHandler(Node *n) {
 }
 
 /* -------------------------------------------------------------------------
- * \brief Process static member functions.
+ * \brief Process global variables.
  */
 int FORTRAN::globalvariableHandler(Node *n) {
-  if (GetFlag(n, "feature:fortran:const")) {
-    return this->constantWrapper(n);
-  }
   if (GetFlag(n, "feature:fortran:bindc")) {
-    String *type = Getattr(n, "type");
-    if (type && strncmp(Char(type), "q(const)", 8) == 0) { 
-      // Treat bindc global const as a non-parameter constant
-      return this->constantWrapper(n);
-    }
     return this->bindcvarWrapper(n);
   }
 

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -2840,7 +2840,7 @@ int FORTRAN::constantWrapper(Node *n) {
 
   // Get Fortran data type
   Swig_typemap_lookup("bindc", n, Getattr(n, "name"), NULL);
-  String *bindc_typestr = Getattr(n, "tmap:bindc:constant");
+  String *bindc_typestr = Getattr(n, "tmap:bindc:fortranconst");
   bool is_native_constant = GetFlagAttr(n, "feature:fortran:const");
 
   // Check for missing typemap
@@ -2848,7 +2848,7 @@ int FORTRAN::constantWrapper(Node *n) {
     if (is_native_constant) {
       Swig_error(input_file,
                  line_number,
-                 "The variable '%s' is marked as %%fortranconst but its type has no 'bindc:constant' typemap.\n",
+                 "The variable '%s' is marked as %%fortranconst but its type has no 'bindc:fortranconst' typemap.\n",
                  Getattr(n, "sym:name"));
       return SWIG_ERROR;
     }

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -2467,6 +2467,14 @@ int FORTRAN::globalfunctionHandler(Node *n) {
   }
 
   if (GetFlag(n, "feature:fortran:bindc")) {
+    if (GetFlagAttr(n, "feature:callback")) {
+      Swig_error(input_file,
+                 line_number,
+                 "Using %%fortranbindc and %%callback on the same function "
+                 "is not supported.\n",
+                 Getattr(n, "sym:name"));
+      return SWIG_ERROR;
+    }
     // The wrapped function name *is* the C function name
     Setattr(n, "wrap:name", Getattr(n, "name"));
     

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -44,6 +44,14 @@ bool is_node_constructor(Node *n) {
   return (Cmp(Getattr(n, "nodeType"), "constructor") == 0 || Getattr(n, "handled_as_constructor"));
 }
 
+/*!
+ * \brief Whether a node is a compile-time constant that isn't acutally defined in client code.
+ */
+bool has_constant_storage(Node *n) {
+  String *s = Getattr(n, "storage");
+  return s && (Cmp(s, "%constant") == 0);
+}
+
 /* -------------------------------------------------------------------------
  * \brief Print a comma-joined line of items to the given output.
  */
@@ -2927,7 +2935,7 @@ int FORTRAN::constantWrapper(Node *n) {
     // Wrap as an external link-time variable (since it could be a complex expression or something that only C can evaluate)
     String *symname = Getattr(n, "sym:name");
     String *wname = NULL;
-    if (!CPlusPlus || Swig_storage_isexternc(n)) {
+    if ((!CPlusPlus && !has_constant_storage(n)) || Swig_storage_isexternc(n)) {
       // Bind directly to the symbol
       wname = Copy(symname);
     } else {

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -2832,16 +2832,15 @@ int FORTRAN::enumDeclaration(Node *n) {
  * treated as global const variables.
  */
 int FORTRAN::constantWrapper(Node *n) {
-  // Get or create a unique fortran identifier
-  String *fsymname = this->get_fsymname(n);
-  if (!fsymname) {
-    return SWIG_ERROR;
-  }
-
   if (d_enum_public) {
-    // We're wrapping a native enumerator: add to the list of enums being built
+    // We're wrapping a native enumerator.
+    String *fsymname = this->get_fsymname(n);
+    if (!fsymname) {
+      return SWIG_ERROR;
+    }
+
+    // Add to list of public enums
     Append(d_enum_public, fsymname);
-    // Print the enum to the list
     Printv(f_fdecl, "  enumerator :: ", fsymname, NULL);
     if (String *value = Getattr(n, "enumvalue")) {
       Printv(f_fdecl, " = ", value, NULL);
@@ -2880,6 +2879,15 @@ int FORTRAN::constantWrapper(Node *n) {
   }
   if (!value) {
     value = Getattr(n, "value");
+  }
+
+  // Get or create a unique fortran identifier *after* we've confirmed it's
+  // going to be wrapped as a constant. Otherwise "getter" functions sent to
+  // globalvariableHandler above will be renamed so that they lose the `get_`
+  // prefix.
+  String *fsymname = this->get_fsymname(n);
+  if (!fsymname) {
+    return SWIG_ERROR;
   }
 
   if (is_native_constant) {


### PR DESCRIPTION
This makes the behavior of %constant more automatic and predictable, as well as making const global data behavior consistent with main SWIG codes.