### PR TITLE
Fix XL compiler errors, ignore others

### DIFF
--- a/Examples/test-suite/fortran/arrays_global_twodim_runme.F90
+++ b/Examples/test-suite/fortran/arrays_global_twodim_runme.F90
@@ -1,8 +1,8 @@
-! File : arrays_global_twodim.F90
+! File : arrays_global_twodim_runme.F90
 
 #include "fassert.h"
 
-program arrays_global_twodim
+program arrays_global_twodim_runme
   implicit none
 
   call test_int_array

--- a/Lib/fortran/fortranstrings.swg
+++ b/Lib/fortran/fortranstrings.swg
@@ -40,7 +40,7 @@ subroutine %fortrantm(fout, char*)(imout, fout)
   character(kind=C_CHAR), dimension(:), pointer :: chars
   integer(kind=C_SIZE_T) :: i
   call c_f_pointer(imout%data, chars, [imout%size])
-  allocate(character(kind=C_CHAR, len=imout%size) :: fout)
+  allocate(character(len=imout%size) :: fout)
   do i=1, imout%size
     fout(i:i) = char(ichar(chars(i)))
   end do

--- a/Lib/fortran/fundamental.swg
+++ b/Lib/fortran/fundamental.swg
@@ -29,8 +29,8 @@ using std::ptrdiff_t;
 %fragment("SWIG_fin"{bool}, "fsubprograms", noblock=1) {
 subroutine %fortrantm(fin, bool)(finp, iminp)
   use, intrinsic :: ISO_C_BINDING
-  logical, intent(IN) :: finp
-  integer(kind=C_INT), intent(OUT) :: iminp
+  logical, intent(in) :: finp
+  integer(kind=C_INT), intent(out) :: iminp
   if (finp .eqv. .true.) then
     iminp = 1
   else
@@ -42,8 +42,8 @@ end subroutine
 %fragment("SWIG_fout"{bool}, "fsubprograms", noblock=1) {
 subroutine %fortrantm(fout, bool)(imout, fout)
   use, intrinsic :: ISO_C_BINDING
-  integer(kind=C_INT), intent(IN) :: imout
-  logical, intent(OUT) :: fout
+  integer(kind=C_INT), intent(in) :: imout
+  logical, intent(out) :: fout
   ! TODO: fout = (imout /= 0) ???
   if (imout /= 0) then
     fout = .true.


### PR DESCRIPTION
Fixed: string conversion type consistency, where one was `C_CHAR` and another the default type.
```
1516-044 (S) A conversion from type unknown is not permitted.
```

---

Fixed: `arrays_global_twodim.cpptest`, where the runme program name was an unintentional duplicate of the module name

---

Not fixed: `imports.multicpptest`, where a function name is the same in the parent and daughter modules, causing a name collision. SWIG doesn't call the `functionHandler` class in import mode, so unlike the `classHandler` it doesn't do any symbol definitions in the target code.

```
"imports_b.f90", line 45.12: 1513-100 (S) Generic name global_test is the same name as an accessible module procedure. Use a MODULE PROCEDURE statement to make name generic.
```

---

Compiler bug: `multi_import_a.f90` where it's ignoring the `swigclasswrapper` type presumably because the imported upstream module had a private class of the same name.
```
"multi_import_a.f90", line 40.27: 1514-084 (S) Identifier farg1 is being declared with type name swigclasswrapper which has not been defined in a derived type definition.
```

---

Compiler bug: problems with same-name `module procedures` and `generic, nopass` bound procedures:
```
"overload_template.f90", line 48.21: 1514-699 (S) Procedure "swigf_a_foo__swig_0" must have a nonoptional dummy argument that corresponds by position in the argument list to a dummy argument not present in procedure "swigf_foo__swig_3", present and type incompatible, present with different kind type parameters, or present with a different rank.
```

Reproduced this error with:
```f90
module poop
 implicit none
 type, public :: A
 contains
  procedure, private, nopass :: a_foo_1
  procedure, private, nopass :: a_foo_2
  generic :: foo => a_foo_1, a_foo_2
 end type A

 interface foo
  module procedure foo_1, foo_2
 end interface
contains

function foo_1(x) result(y)
  integer, intent(in) :: x
  integer :: y
  y = x
end function
function foo_2(x) result(y)
  real, intent(in) :: x
  real :: y
  y = x
end function

function a_foo_1() result(y)
  integer :: y
  y = 10
end function
function a_foo_2(x) result(y)
  real, intent(in) :: x
  real :: y
  y = x
end function
end module
```