### PR TITLE
Improve, fix, and extend standard library

### DIFF
--- a/Examples/test-suite/abstract_signature.i
+++ b/Examples/test-suite/abstract_signature.i
@@ -2,6 +2,7 @@
 
 %warnfilter(SWIGWARN_RUBY_WRONG_NAME) abstract_foo;	// Ruby, wrong class name
 %warnfilter(SWIGWARN_RUBY_WRONG_NAME) abstract_bar;	// Ruby, wrong class name
+%warnfilter(SWIGWARN_LANG_OVERLOAD_SHADOW) meth; // Fortran prevents overloaded methods from overriding a base class non-overloaded method
 
 %inline %{ 
 class abstract_foo 

--- a/Examples/test-suite/constant_directive.i
+++ b/Examples/test-suite/constant_directive.i
@@ -4,6 +4,9 @@
 
 #ifdef SWIGOCAML
 %warnfilter(SWIGWARN_PARSE_KEYWORD) val;
+#elif SWIGFORTRAN
+// Can't natively wrap function pointers with nonnative return type
+%warnfilter(SWIGWARN_LANG_NATIVE_UNIMPL,SWIGWARN_TYPEMAP_UNDEF) TYPE1FPTR1_CONSTANT1;
 #endif
 
 %inline %{

--- a/Examples/test-suite/fortran/Makefile.in
+++ b/Examples/test-suite/fortran/Makefile.in
@@ -52,7 +52,6 @@ FAILING_CPP_TESTS += \
 	smart_pointer_member \
 	smart_pointer_template_defaults_overload \
 	typedef_classforward_same_name \
-	li_std_map \
 	cpp11_result_of \
 	cpp11_rvalue_reference2 \
 	cpp11_rvalue_reference3 \

--- a/Examples/test-suite/fortran/li_std_map_runme.F90
+++ b/Examples/test-suite/fortran/li_std_map_runme.F90
@@ -1,0 +1,73 @@
+! File : li_std_map_runme.f90
+
+#include "fassert.h"
+
+program li_std_map_runme
+  use ISO_C_BINDING
+  implicit none
+
+  call test_map_int_int
+  call test_map_string_int
+contains
+
+subroutine test_map_int_int
+  use ISO_C_BINDING
+  ! Note that the test instantiates *multiset* as a set_int
+  use li_std_map, only : MapIntInt => IntIntMap
+  implicit none
+  type(MapIntInt) :: m
+  integer :: num_erased
+  logical :: inserted = .false.
+
+  m = MapIntInt()
+  ASSERT(m%empty())
+
+  call m%insert(10, 4)
+  call m%insert(3, 5, inserted)
+  ASSERT(inserted .eqv. .true.)
+  ASSERT(m%size() == 2)
+  ASSERT(m%count(3) == 1)
+  ASSERT(m%count(5) == 0)
+
+  ! Insertion of existing element will *not* replace value
+  call m%insert(3, 6, inserted)
+  ASSERT(inserted .eqv. .false.)
+  ASSERT(m%count(3) == 1)
+  ASSERT(m%size() == 2)
+  ASSERT(m%get(3) == 5)
+
+  ! Use "set" method to unconditionally assign
+  call m%set(3, 6)
+  ASSERT(m%get(3) == 6)
+
+  call m%erase(10)
+  ASSERT(m%size() == 1)
+  ASSERT(m%count(10) == 0)
+
+  call m%erase(3, num_erased)
+  ASSERT(num_erased == 1)
+  ASSERT(m%count(3) == 0)
+
+  call m%release()
+end subroutine
+
+subroutine test_map_string_int
+  use ISO_C_BINDING
+  use li_std_map, only : MapStringInt => StringIntMap
+  implicit none
+  type(MapStringInt) :: m
+
+  m = MapStringInt()
+  ASSERT(m%empty())
+
+  call m%insert("yoohoo", 10)
+  call m%insert("howdy", 5)
+  ASSERT(m%size() == 2)
+  ASSERT(m%count("yoohoo") == 1)
+  ASSERT(m%count("hiya") == 0)
+  ASSERT(m%get("yoohoo") == 10)
+  call m%release()
+end subroutine
+
+end program
+

--- a/Examples/test-suite/fortran/li_std_set_runme.F90
+++ b/Examples/test-suite/fortran/li_std_set_runme.F90
@@ -52,17 +52,20 @@ subroutine test_set_string
   use li_std_set, only : set_string
   implicit none
   type(set_string) :: s
+  logical :: inserted = .false.
 
   s = set_string()
   ASSERT(s%empty())
 
   call s%insert("yoohoo")
-  call s%insert("howdy")
+  call s%insert("howdy", inserted)
+  ASSERT(inserted .eqv. .true.)
   ASSERT(s%size() == 2)
   ASSERT(s%count("yoohoo") == 1)
   ASSERT(s%count("hiya") == 0)
 
-  call s%insert("howdy")
+  call s%insert("howdy", inserted)
+  ASSERT(inserted .eqv. .false.)
   ASSERT(s%count("howdy") == 1)
   ASSERT(s%size() == 2)
 

--- a/Examples/test-suite/fortran/li_std_string_runme.F90
+++ b/Examples/test-suite/fortran/li_std_string_runme.F90
@@ -1,0 +1,25 @@
+! File : li_std_string_runme.f90
+
+#include "fassert.h"
+
+program li_std_string_runme
+  use li_std_string
+  use ISO_C_BINDING
+  implicit none
+  character(kind=C_CHAR, len=*), parameter :: mystring = "howdy!"
+  character(kind=C_CHAR, len=:), allocatable :: actual
+  type(swigtype_p_std__string) :: anonymous_string
+
+  allocate(actual, source=test_value(mystring))
+  ASSERT(actual == mystring)
+  deallocate(actual)
+
+  actual = test_const_reference(mystring)
+  ASSERT(actual == mystring)
+  deallocate(actual)
+
+  call test_pointer(anonymous_string)
+
+  anonymous_string = test_pointer_out()
+end program
+

--- a/Examples/test-suite/fortran_ownership.i
+++ b/Examples/test-suite/fortran_ownership.i
@@ -76,3 +76,18 @@ void do_nothing(TemplTricky<int>) {};
 %}
 
 %template(TemplTrickyInt) myns::TemplTricky<int>;
+
+// Test autofree declaration *before* including std:string
+%fortran_autofree_rvalue(std::string)
+namespace std {
+class string {
+};
+}
+
+%include <std_string.i>
+
+%inline %{
+std::string str_value(std::string s) { return s; }
+const std::string& str_cref(const std::string& s) { return s; }
+std::string& str_ref(std::string& s) { return s; }
+%}

--- a/Lib/fortran/std_map.i
+++ b/Lib/fortran/std_map.i
@@ -2,8 +2,60 @@
  * std_map.i
  * ------------------------------------------------------------------------- */
 
+%include "std_common.i"
+
 %{
 #include <map>
 %}
-#error "std::map support is not yet implemented"
 
+%define %swig_std_map(_Key, _Value, _Compare)
+
+public:
+  typedef size_t size_type;
+  typedef ptrdiff_t difference_type;
+  typedef _Key key_type;
+  typedef _Value mapped_type;
+  typedef std::pair<const _Key, _Value> value_type;
+  typedef value_type *pointer;
+  typedef const value_type *const_pointer;
+  typedef value_type &reference;
+  typedef const value_type &const_reference;
+
+  map();
+
+  // - Use native Fortran integers in proxy code
+  %apply int FORTRAN_INT {size_type};
+
+  bool empty() const;
+  size_type size() const;
+  void clear();
+
+  %fortransubroutine erase;
+
+  size_type erase(const key_type &x);
+  size_type count(const key_type &x) const;
+
+  %fortransubroutine insert;
+
+  %extend {
+    bool insert(const _Key& k, const _Value& v) {
+      std::pair<std::map<_Key, _Value, _Compare >::iterator, bool> result = $self->insert(std::pair<_Key, _Value>(k, v));
+      return result.second;
+    }
+
+    const _Value& get(const _Key& k) {
+      return (*$self)[k];
+    }
+    void set(const _Key& k, const _Value& v) {
+      (*$self)[k] = v;
+    }
+  }
+
+%enddef
+
+namespace std {
+template<class _Key, class _Value, class _Compare = std::less<_Key > >
+class map {
+  %swig_std_map(_Key, _Value, _Compare);
+};
+} // namespace std

--- a/Lib/fortran/std_multiset.i
+++ b/Lib/fortran/std_multiset.i
@@ -7,10 +7,14 @@
 
 %include "std_set.i"
 
+%define %swig_std_multiset(_Key, _Compare, _Alloc)
+  %swig_std_setcommon(multiset, _Key, _Compare, _Alloc)
+%enddef
+
 namespace std {
 template<class _Key, class _Compare = std::less<_Key>, class _Alloc = std::allocator<_Key> >
 class multiset {
-  SWIG_STD_SET_COMMON(multiset, _Key, _Compare, _Alloc)
+  %swig_std_multiset( _Key, _Compare, _Alloc)
 };
 } // end namespace std
 

--- a/Lib/fortran/std_multiset.i
+++ b/Lib/fortran/std_multiset.i
@@ -9,6 +9,8 @@
 
 %define %swig_std_multiset(_Key, _Compare, _Alloc)
   %swig_std_setcommon(multiset, _Key, _Compare, _Alloc)
+
+  void insert(const_reference x);
 %enddef
 
 namespace std {

--- a/Lib/fortran/std_set.i
+++ b/Lib/fortran/std_set.i
@@ -37,11 +37,19 @@ public:
 
   size_type erase(const key_type& x);
   size_type count(const key_type& x) const;
-  void insert(const_reference x);
 %enddef
 
 %define %swig_std_set(_Key, _Compare, _Alloc)
   %swig_std_setcommon(set, _Key, _Compare, _Alloc)
+
+  %fortransubroutine insert;
+
+  %extend {
+    bool insert(const_reference x) {
+      std::pair<std::set<_Key, _Compare, _Alloc >::iterator, bool> result = $self->insert(x);
+      return result.second;
+    }
+  }
 %enddef
 
 namespace std {

--- a/Lib/fortran/std_set.i
+++ b/Lib/fortran/std_set.i
@@ -8,7 +8,8 @@
 #include <set>
 %}
 
-%define SWIG_STD_SET_COMMON(CLASS, _Key, _Compare, _Alloc)
+// methods used by both set *and* multiset
+%define %swig_std_setcommon(CLASS, _Key, _Compare, _Alloc)
 
 public:
   // Typedefs
@@ -37,13 +38,16 @@ public:
   size_type erase(const key_type& x);
   size_type count(const key_type& x) const;
   void insert(const_reference x);
+%enddef
 
+%define %swig_std_set(_Key, _Compare, _Alloc)
+  %swig_std_setcommon(set, _Key, _Compare, _Alloc)
 %enddef
 
 namespace std {
 template<class _Key, class _Compare = std::less<_Key>, class _Alloc = std::allocator<_Key> >
 class set {
-  SWIG_STD_SET_COMMON(set, _Key, _Compare, _Alloc)
+  %swig_std_set(_Key, _Compare, _Alloc)
 };
 } // end namespace std
 

--- a/Lib/fortran/std_string.i
+++ b/Lib/fortran/std_string.i
@@ -30,45 +30,12 @@ namespace std {
 class string;
 }
 
-/* ---- CONST REFERENCE: NATIVE STRING ---- */
-
-%clear const std::string &;
-%typemap(ctype) const std::string & = char*;
-%typemap(imtype) const std::string & = char*;
-%typemap(ftype) const std::string & = char*;
-
-// C input translation typemaps: $1 is std::string*, $input is SwigArrayWrapper
-%typemap(in, noblock=1) const std::string & (std::string tempstr) {
-  tempstr = std::string(static_cast<char *>($input->data), $input->size);
-  $1 = &tempstr;
-}
-
-// C output translation typemaps: $1 is string*, $input is SwigArrayWrapper
-%typemap(out, noblock=1) const std::string & {
-  $result.data = ($1->empty() ? NULL : &(*$1->begin()));
-  $result.size = $1->size();
-}
-
-// Fortran proxy translation code: convert from char array to Fortran string
-%typemap(fin) const std::string & = char*;
-// Unlike char* code, we never delete the return value!
-%typemap(fout, noblock=1, fragment="SWIG_fout"{char*}) const std::string & {
-  call %fortrantm(fout, char*)($1, $result)
-}
-
 /* ---- VALUE: NATIVE STRING ---- */
 
 %clear std::string;
-%apply const std::string & { std::string };
 
-%typemap(globalin) std::string {
-   $1 = *$input;
-}
-%typemap(memberin) std::string {
-   $1 = *$input;
-}
+%typemap(ctype) std::string = char*;
 
-// Copy input data to local string
 %typemap(in, noblock=1) std::string {
   $1.assign(static_cast<char *>($input->data), $input->size);
 }
@@ -84,9 +51,37 @@ class string;
   }
 }
 
+%typemap(imtype) std::string = char*;
+%typemap(ftype) std::string = char*;
+
+// Fortran proxy translation code: convert from char array to Fortran string
+%typemap(fin) std::string = char*;
+
 // Fortran proxy translation code: convert from char array to Fortran string
 %typemap(fout, noblock=1,
          fragment="SWIG_free_f", fragment="SWIG_fout"{char*}) std::string {
   call %fortrantm(fout, char*)($1, $result)
   call SWIG_free($1%data)
+}
+
+/* ---- CONST REFERENCE: NATIVE STRING ---- */
+
+// Use the same
+%clear const std::string &;
+%apply std::string { const std::string & };
+
+// Construct a temporary string from the Fortran character array
+%typemap(in, noblock=1) const std::string & (std::string tempstr) {
+  tempstr = std::string(static_cast<char *>($input->data), $input->size);
+  $1 = &tempstr;
+}
+
+%typemap(out, noblock=1, fragment="<stdlib.h>", fragment="<string.h>") const std::string & {
+  $result.size = $1->size();
+  if ($result.size > 0) {
+    $result.data = malloc($result.size);
+    memcpy($result.data, $1->c_str(), $result.size);
+  } else {
+    $result.data = NULL;
+  }
 }

--- a/Lib/fortran/std_string.i
+++ b/Lib/fortran/std_string.i
@@ -32,6 +32,7 @@ class string;
 
 /* ---- CONST REFERENCE: NATIVE STRING ---- */
 
+%clear const std::string &;
 %typemap(ctype) const std::string & = char*;
 %typemap(imtype) const std::string & = char*;
 %typemap(ftype) const std::string & = char*;
@@ -57,6 +58,7 @@ class string;
 
 /* ---- VALUE: NATIVE STRING ---- */
 
+%clear std::string;
 %apply const std::string & { std::string };
 
 %typemap(globalin) std::string {

--- a/Lib/fortran/std_vector.i
+++ b/Lib/fortran/std_vector.i
@@ -20,7 +20,7 @@
 #include <vector>
 %}
 
-%define SWIG_STD_VECTOR_COMMON(CTYPE, CREF_TYPE)
+%define %swig_std_vector(CTYPE, CREF_TYPE)
   public:
     // Typedefs
     typedef size_t size_type;
@@ -109,7 +109,7 @@
     }
 %enddef
 
-%define SWIG_STD_VECTOR_REF(CTYPE)
+%define %swig_std_vector_extend_ref(CTYPE)
   %extend {
     CTYPE& front_ref() {
       return (*$self).front();
@@ -128,13 +128,13 @@
 
 namespace std {
   template<class T> class vector {
-    SWIG_STD_VECTOR_COMMON(T, const T&)
-    SWIG_STD_VECTOR_REF(T)
+    %swig_std_vector(T, const T&)
+    %swig_std_vector_extend_ref(T)
   };
 
   // bool specialization
   template<> class vector<bool> {
-    SWIG_STD_VECTOR_COMMON(bool, bool)
+    %swig_std_vector(bool, bool)
   };
 } // end namespace std
 

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -1461,6 +1461,9 @@ Wrapper *FORTRAN::imfuncWrapper(Node *n, bool bindc) {
 
   // Attach typemap for return value
   String *return_imtype = attach_typemap(tmtype, n, warning_flag);
+  if (bindc && !return_imtype) {
+    return NULL;
+  }
   this->replace_fclassname(n, return_cpptype, return_imtype);
 
   const bool is_imsubroutine = (Len(return_imtype) == 0);


### PR DESCRIPTION
- Fix incompatibility between `std::string` and `autofree_rvalue`
- Change std container macro names to be more like other swig languages
- Add optional result value for successful `std::set` insertion
- Add initial `std::map` implementation