### PR TITLE
Rename methods that become too long when overloaded

### DIFF
--- a/Examples/test-suite/fortran/fortran_naming_runme.F90
+++ b/Examples/test-suite/fortran/fortran_naming_runme.F90
@@ -62,6 +62,9 @@ program fortran_naming_runme
   ASSERT(sixty_four_characters_is_way_too_long_for_fortran_or_punchXAJBV == 65)
   ASSERT(leading_underscore_with_sixty_four_characters_is_just_darnIR2OS == 64)
   ASSERT(leading_underscore_with_sixty_three_characters_might_be_tricky_ == 63)
+  ASSERT(this_is_a_very_long_name_but_its_ok_unless_its_overloaded() == 0)
+  ASSERT(this_is_a_very_long_name_but_its_bad_since_its_overloaded(10) == 10)
+  ASSERT(this_is_a_very_long_name_but_its_bad_since_its_overloaded(20.0) == 20.0)
 
   ! Check elided enum
   ASSERT(Zero == 0)

--- a/Examples/test-suite/fortran_naming.i
+++ b/Examples/test-suite/fortran_naming.i
@@ -120,6 +120,13 @@ extern "C" int _0cboundfunc(const int _x) { return _x + 1; }
 %constant int _leading_underscore_with_sixty_three_characters_might_be_tricky = 63;
 %nofortranconst;
 
+// swigc_ -prefixed name: OK if not overloaded, too long if overloaded
+%inline %{
+int this_is_a_very_long_name_but_its_ok_unless_its_overloaded() { return 0; }
+int this_is_a_very_long_name_but_its_bad_since_its_overloaded(int i) { return i; }
+float this_is_a_very_long_name_but_its_bad_since_its_overloaded(float f) { return f; }
+%}
+
 // This class is poorly named, but the symname is OK.
 %inline %{
 template<class T>


### PR DESCRIPTION
Wrapper names that were 56–62 characters wouldn't need renaming if standalone, but adding the `__SWIG_0` overload suffix causes them to exceed the fortran identifier length limit. This fixes such cases.