### PR TITLE
Normalize size_t usage in Fortran

### DIFF
--- a/Examples/test-suite/fortran/typedef_sizet_runme.F90
+++ b/Examples/test-suite/fortran/typedef_sizet_runme.F90
@@ -1,0 +1,14 @@
+! File : typedef_sizet_runme.F90
+
+#include "fassert.h"
+
+program typedef_sizet_runme
+  use typedef_sizet
+  use ISO_C_BINDING
+  implicit none
+  integer(C_SIZE_T) :: inp, outp
+
+  inp = 1234_c_size_t
+  outp = identity_size(inp)
+  ASSERT(inp == outp)
+end program

--- a/Examples/test-suite/typedef_sizet.i
+++ b/Examples/test-suite/typedef_sizet.i
@@ -1,6 +1,11 @@
 %module typedef_sizet
 
+#ifdef SWIGFORTRAN
+// Avoid shadowing intrinsic size
+%rename("identity_size") size;
+#endif
+
 typedef unsigned long long size_t;
 %inline %{
-size_t size(size_t x) {return x; } 
+size_t size(size_t x) {return x; }
 %}

--- a/Lib/fortran/fundamental.swg
+++ b/Lib/fortran/fundamental.swg
@@ -10,18 +10,6 @@
 
 %include <typemaps/swigmacros.swg>
 
-#ifdef __cplusplus
-namespace std
-{
-#endif
-typedef unsigned long long size_t;
-typedef long long ptrdiff_t;
-#ifdef __cplusplus
-}
-using std::size_t;
-using std::ptrdiff_t;
-#endif
-
 /* -------------------------------------------------------------------------
  * FRAGMENTS
  * ------------------------------------------------------------------------- */

--- a/Lib/fortran/std_set.i
+++ b/Lib/fortran/std_set.i
@@ -15,7 +15,7 @@ public:
   // Typedefs
   typedef _Key value_type;
   typedef _Key key_type;
-  typedef std::size_t size_type;
+  typedef size_t size_type;
   typedef ptrdiff_t difference_type;
   typedef value_type *pointer;
   typedef const value_type *const_pointer;


### PR DESCRIPTION
This is more similar to the behavior in the rest of SWIG and prevents downstream `size_t` from being unintentionally converted to ULL.